### PR TITLE
Add option to create install log file (Windows)

### DIFF
--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -64,13 +64,15 @@ def install_update(
     )
 
 
-WIN_DEBUG_FILENAME = 'install.log'
+WIN_LOG_FILENAME = 'install.log'
+WIN_LOG_LINES = """
+call :log > "{log_file_path}" 2>&1
+:log
+"""
 WIN_DEBUG_LINES = """
 rem wait for user confirmation (allow user to read any error messages)
 timeout /t -1
 """
-# redirect stderr to stdout and pipe into file via tee (requires powershell)
-WIN_DEBUG_COMMAND = '2>&1 | powershell -C "$Input | tee {log_file_path}"'
 WIN_ROBOCOPY_OVERWRITE = (
     '/e',  # include subdirectories, even if empty
     '/move',  # deletes files and dirs from source dir after they've been copied
@@ -81,12 +83,12 @@ WIN_ROBOCOPY_EXCLUDE_FROM_PURGE = '/xf'  # exclude specified paths from purge
 
 # https://stackoverflow.com/a/20333575
 WIN_MOVE_FILES_BAT = """@echo off
+{log_lines}
 echo Moving app files...
 rem wait a few seconds for caller to relinquish locks etc. 
 timeout /t 2
 robocopy "{src}" "{dst}" {options}
 echo Done.
-{debug_lines}
 rem Delete self
 (goto) 2>nul & del "%~f0"
 """
@@ -131,8 +133,8 @@ def _install_update_win(
 
     The `as_admin` options allows installation as admin (opens UAC dialog).
 
-    The `debug` option will keep the console open so we can investigate
-    issues with robocopy.
+    The `debug` option will log the output of the install script to a file in
+    the dst_dir.
 
     Options for [robocopy][1] can be overridden completely by passing a list
     of option strings to `robocopy_options_override`. This will cause the
@@ -151,15 +153,13 @@ def _install_update_win(
         # empty list [] simply clears all options
         options = robocopy_options_override
     options_str = ' '.join(options)
-    debug_lines = ''
-    debug_command = ''
+    log_lines = ''
     if debug:
-        #debug_lines = WIN_DEBUG_LINES
-        debug_command = WIN_DEBUG_COMMAND.format(
-            log_file_path=pathlib.Path(dst_dir) / WIN_DEBUG_FILENAME
-        )
+        log_file_path = pathlib.Path(dst_dir) / WIN_LOG_FILENAME
+        log_lines = WIN_LOG_LINES.format(log_file_path=log_file_path)
+        logger.info(f'logging install script output to {log_file_path}')
     script_content = WIN_MOVE_FILES_BAT.format(
-        src=src_dir, dst=dst_dir, options=options_str, debug_lines=debug_lines
+        src=src_dir, dst=dst_dir, options=options_str, log_lines=log_lines
     )
     logger.debug(f'writing windows batch script:\n{script_content}')
     with NamedTemporaryFile(
@@ -173,11 +173,9 @@ def _install_update_win(
     if as_admin:
         run_bat_as_admin(file_path=script_path)
     else:
-        # we use Popen() instead of run(), because the latter waits for the
-        # process to complete
+        # we use Popen() instead of run(), because the latter blocks execution
         subprocess.Popen(
-            str(script_path) + debug_command,
-            creationflags=subprocess.CREATE_NEW_CONSOLE,
+            [script_path], creationflags=subprocess.CREATE_NEW_CONSOLE
         )
     logger.debug('exiting')
     sys.exit(0)

--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -64,14 +64,9 @@ def install_update(
     )
 
 
-WIN_LOG_FILENAME = 'install.log'
 WIN_LOG_LINES = """
 call :log > "{log_file_path}" 2>&1
 :log
-"""
-WIN_DEBUG_LINES = """
-rem wait for user confirmation (allow user to read any error messages)
-timeout /t -1
 """
 WIN_ROBOCOPY_OVERWRITE = (
     '/e',  # include subdirectories, even if empty
@@ -121,7 +116,7 @@ def _install_update_win(
         purge_dst_dir: bool,
         exclude_from_purge: List[Union[pathlib.Path, str]],
         as_admin: bool = False,
-        debug: bool = False,
+        log_file_name: str = None,
         robocopy_options_override: List[str] = None,
 ):
     """
@@ -154,8 +149,8 @@ def _install_update_win(
         options = robocopy_options_override
     options_str = ' '.join(options)
     log_lines = ''
-    if debug:
-        log_file_path = pathlib.Path(dst_dir) / WIN_LOG_FILENAME
+    if log_file_name:
+        log_file_path = pathlib.Path(dst_dir) / log_file_name
         log_lines = WIN_LOG_LINES.format(log_file_path=log_file_path)
         logger.info(f'logging install script output to {log_file_path}')
     script_content = WIN_MOVE_FILES_BAT.format(

--- a/tests/test_utils_platform_specific.py
+++ b/tests/test_utils_platform_specific.py
@@ -7,7 +7,7 @@ import unittest
 
 from tests import BASE_DIR, TempDirTestCase
 from tufup.utils.platform_specific import (
-    ON_WINDOWS, PLATFORM_SUPPORTED, run_bat_as_admin, WIN_DEBUG_FILENAME
+    ON_WINDOWS, PLATFORM_SUPPORTED, run_bat_as_admin, WIN_LOG_FILENAME
 )
 
 _reason_platform_not_supported = (
@@ -156,6 +156,7 @@ class UtilsTests(TempDirTestCase):
         # run the dummy app in a separate process
         self.run_dummy_app(extra_kwargs_strings=extra_kwargs_strings)
         # a log file should exist
-        log_file_path = self.dst_dir / WIN_DEBUG_FILENAME
+        log_file_path = self.dst_dir / WIN_LOG_FILENAME
         self.assertTrue(log_file_path.exists())
-        print(log_file_path.read_text())
+        log_file_content = log_file_path.read_text()
+        self.assertTrue(log_file_content)

--- a/tests/test_utils_platform_specific.py
+++ b/tests/test_utils_platform_specific.py
@@ -7,7 +7,7 @@ import unittest
 
 from tests import BASE_DIR, TempDirTestCase
 from tufup.utils.platform_specific import (
-    ON_WINDOWS, PLATFORM_SUPPORTED, run_bat_as_admin
+    ON_WINDOWS, PLATFORM_SUPPORTED, run_bat_as_admin, WIN_DEBUG_FILENAME
 )
 
 _reason_platform_not_supported = (
@@ -145,3 +145,17 @@ class UtilsTests(TempDirTestCase):
         self.assertTrue(self.dst_subdir.exists())
         # file to keep must still be present
         self.assertTrue(self.keep_file_path.exists())
+
+    @unittest.skipIf(
+        condition=not ON_WINDOWS, reason='install.log file is windows only'
+    )
+    def test_install_update_debug_log_file(self):
+        extra_kwargs_strings = [
+            'as_admin=False', 'debug=True', 'robocopy_options_override=[]'
+        ]
+        # run the dummy app in a separate process
+        self.run_dummy_app(extra_kwargs_strings=extra_kwargs_strings)
+        # a log file should exist
+        log_file_path = self.dst_dir / WIN_DEBUG_FILENAME
+        self.assertTrue(log_file_path.exists())
+        print(log_file_path.read_text())

--- a/tests/test_utils_platform_specific.py
+++ b/tests/test_utils_platform_specific.py
@@ -7,7 +7,7 @@ import unittest
 
 from tests import BASE_DIR, TempDirTestCase
 from tufup.utils.platform_specific import (
-    ON_WINDOWS, PLATFORM_SUPPORTED, run_bat_as_admin, WIN_LOG_FILENAME
+    ON_WINDOWS, PLATFORM_SUPPORTED, run_bat_as_admin
 )
 
 _reason_platform_not_supported = (
@@ -89,7 +89,7 @@ class UtilsTests(TempDirTestCase):
     def test_install_update_no_purge(self):
         extra_kwargs_strings = []
         if ON_WINDOWS:
-            extra_kwargs_strings.extend(['as_admin=False', 'debug=False'])
+            extra_kwargs_strings.extend(['as_admin=False', 'log_file_name=None'])
         # run the dummy app in a separate process
         self.run_dummy_app(extra_kwargs_strings=extra_kwargs_strings)
         # ensure file has been moved from src to dst
@@ -112,7 +112,7 @@ class UtilsTests(TempDirTestCase):
             'purge_dst_dir=True', f'exclude_from_purge=["{self.keep_file_str}"]'
         ]
         if ON_WINDOWS:
-            extra_kwargs_strings.extend(['as_admin=False', 'debug=False'])
+            extra_kwargs_strings.extend(['as_admin=False', 'log_file_name=None'])
         # run the dummy app in a separate process
         self.run_dummy_app(extra_kwargs_strings=extra_kwargs_strings)
         # ensure file has been moved from src to dst
@@ -130,7 +130,7 @@ class UtilsTests(TempDirTestCase):
     @unittest.skipIf(condition=not ON_WINDOWS, reason='robocopy is windows only')
     def test_install_update_robocopy_options_override(self):
         extra_kwargs_strings = [
-            'as_admin=False', 'debug=False', 'robocopy_options_override=[]'
+            'as_admin=False', 'log_file_name=None', 'robocopy_options_override=[]'
         ]
         # run the dummy app in a separate process
         self.run_dummy_app(extra_kwargs_strings=extra_kwargs_strings)
@@ -149,14 +149,17 @@ class UtilsTests(TempDirTestCase):
     @unittest.skipIf(
         condition=not ON_WINDOWS, reason='install.log file is windows only'
     )
-    def test_install_update_debug_log_file(self):
+    def test_install_update_log_file(self):
+        log_file_name = 'install.log'
         extra_kwargs_strings = [
-            'as_admin=False', 'debug=True', 'robocopy_options_override=[]'
+            'as_admin=False',
+            f'log_file_name="{log_file_name}"',
+            'robocopy_options_override=[]',
         ]
         # run the dummy app in a separate process
         self.run_dummy_app(extra_kwargs_strings=extra_kwargs_strings)
         # a log file should exist
-        log_file_path = self.dst_dir / WIN_LOG_FILENAME
+        log_file_path = self.dst_dir / log_file_name
         self.assertTrue(log_file_path.exists())
         log_file_content = log_file_path.read_text()
         self.assertTrue(log_file_content)


### PR DESCRIPTION
Default windows install script is modified so output and errors are redirected to a log file.
The optional `debug` argument is replaced by an optional `log_file_name` argument.
