### PR TITLE
Fix issue 44: tuf dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42"]
+requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,16 @@
-# to upgrade packages in existing env: pip install -r requirements.txt --upgrade
+# install requirements from setup.cfg by calling `pip install .` from project root
 
-bsdiff4==1.2.*
-packaging==21.*
-requests
-securesystemslib[crypto,pynacl]==0.22.*
-setuptools>=61.0.0
-tuf==2.*
+bsdiff4==1.2.2
+certifi==2022.9.24
+cffi==1.15.1
+charset-normalizer==2.1.1
+cryptography==38.0.1
+idna==3.4
+packaging==21.3
+pycparser==2.21
+PyNaCl==1.5.0
+pyparsing==3.0.9
+requests==2.28.1
+securesystemslib==0.24.0
+tuf==2.0.0
+urllib3==1.26.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ PyNaCl==1.5.0
 pyparsing==3.0.9
 requests==2.28.1
 securesystemslib==0.24.0
+setuptools==63.2.0
 tuf==2.0.0
 urllib3==1.26.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,8 +23,8 @@ python_requires = >=3.8
 install_requires =
     bsdiff4==1.2.*
     packaging==21.*
-    securesystemslib[crypto,pynacl]==0.22.*
-    tuf==1.1.*
+    securesystemslib[crypto,pynacl]==0.24.*
+    tuf==2.*
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     bsdiff4==1.2.*
     packaging==21.*
     securesystemslib[crypto,pynacl]==0.24.*
+    setuptools>=61.*.*
     tuf==2.*
 
 [options.packages.find]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+
+from packaging.version import Version
+import tuf
+
+
+class PackageTests(TestCase):
+    def test_tuf_version(self):
+        # quick & dirty regression test for issue 44
+        self.assertGreaterEqual(Version(tuf.__version__), Version('2'))


### PR DESCRIPTION
Fixes #44 

- bumped tuf version in setup.cfg
- bumped setuptools version

Install dependencies from setup.cfg using `pip install .` (from project root directory), then freeze into requirements.txt

Note that we use a function from `setuptools` on the repo side, but `setuptools` is considered special, so it is excluded from the `pip freeze` output... See e.g. this interesting discussion: https://github.com/pypa/pipenv/issues/1417