### PR TITLE
Fix issue 47: enable custom batch templates

### DIFF
--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -137,12 +137,25 @@ def _install_update_win(
 
     The `as_admin` options allows installation as admin (opens UAC dialog).
 
-    The `debug` option will log the output of the install script to a file in
-    the dst_dir.
+    The `batch_template` option allows specification of custom batch-file
+    content. This may be in the form of a template string, as in the default
+    `WIN_BATCH_TEMPLATE`, or it may be a ready-made string without any
+    template variables. The following default template variables are
+    available for use in the custom template, although their use is optional:
+    {log_lines}, {src_dir}, {dst_dir}, {robocopy_options}, {delete_self}.
+    Custom template variables can be used as well, in which case you'll need
+    to specify `batch_template_extra_kwargs`.
 
-    Options for [robocopy][1] can be overridden completely by passing a list
-    of option strings to `robocopy_options_override`. This will cause the
-    purge arguments to be ignored as well.
+    The `batch_template_extra_kwargs` options allows specification of custom
+    template arguments. It accepts a dict, with keys matching the *custom*
+    template variable names specified in the `batch_template`.
+
+    The `log_file_name` option will log the output of the install script to a
+    file in the `dst_dir`.
+
+    The `robocopy_options_override` option allows options for [robocopy][1]
+    to be overridden completely. It accepts a list of option strings. This
+    will cause the purge arguments to be ignored as well.
 
     [1]: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy
     """

--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -81,7 +81,7 @@ WIN_ROBOCOPY_PURGE = '/purge'  # delete all files and dirs in destination folder
 WIN_ROBOCOPY_EXCLUDE_FROM_PURGE = '/xf'  # exclude specified paths from purge
 
 # https://stackoverflow.com/a/20333575
-WIN_MOVE_FILES_BAT = """@echo off
+WIN_BATCH_TEMPLATE = """@echo off
 {log_lines}
 echo Moving app files...
 robocopy "{src}" "{dst}" {options}
@@ -139,6 +139,7 @@ def _install_update_win(
 
     [1]: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy
     """
+    # collect robocopy options
     if robocopy_options_override is None:
         options = list(WIN_ROBOCOPY_OVERWRITE)
         if purge_dst_dir:
@@ -150,12 +151,14 @@ def _install_update_win(
         # empty list [] simply clears all options
         options = robocopy_options_override
     options_str = ' '.join(options)
+    # handle batch file output logging
     log_lines = ''
     if log_file_name:
         log_file_path = pathlib.Path(dst_dir) / log_file_name
         log_lines = WIN_LOG_LINES.format(log_file_path=log_file_path)
         logger.info(f'logging install script output to {log_file_path}')
-    script_content = WIN_MOVE_FILES_BAT.format(
+    # write temporary batch file
+    script_content = WIN_BATCH_TEMPLATE.format(
         src=src_dir, dst=dst_dir, options=options_str, log_lines=log_lines
     )
     logger.debug(f'writing windows batch script:\n{script_content}')
@@ -175,6 +178,7 @@ def _install_update_win(
             [script_path], creationflags=subprocess.CREATE_NEW_CONSOLE
         )
     logger.debug('exiting')
+    # exit current process
     sys.exit(0)
 
 

--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -146,8 +146,9 @@ def _install_update_win(
     Custom template variables can be used as well, in which case you'll need
     to specify `batch_template_extra_kwargs`.
 
-    The `batch_template_extra_kwargs` options allows specification of custom
-    template arguments. It accepts a dict, with keys matching the *custom*
+    The `batch_template_extra_kwargs` options allows specification of
+    *custom* template variables (in addition to the default ones, which are
+    always available). It accepts a dict, with keys matching the *custom*
     template variable names specified in the `batch_template`.
 
     The `log_file_name` option will log the output of the install script to a


### PR DESCRIPTION
fixes #47 

In addition to the existing `install` function override, this PR adds the ability for users to supply a custom batch template (for windows), by passing a `batch_template` argument to `Client.download_and_install_update()`.

The default template `WIN_BATCH_TEMPLATE` can be used as an example.

The following default variables are available for use in the custom template, but they can also be omitted: 
- `{log_lines}`  inserts lines that cause batch file output to be logged to file
- `{src_dir}`  inserts path to source directory
- `{dst_dir}` inserts path to destination directory
- `{robocopy_options}`  inserts robocopy options (default or custom)
- `{delete_self}` inserts a line that causes the batch file to delete itself (should only be used at end of file)

The user can also introduce custom template variables, e.g. `{my_variable}`, or they can pass a pre-filled template without any variables.

If custom template variables are used, they must be passed into `Client.download_and_install_update()` using the `batch_template_extra_kwargs` argument.

Usage example (note this template doesn't do anything useful):

```python
custom_template = """
echo {custom_content}> "{custom_file_path}"
{delete_self}
"""
custom_template_variables = dict(
    custom_content='some content',
    custom_file_path=r'some\file\path',
)

...

client.download_and_install_update(
    ..., 
    batch_template=custom_template, 
    batch_template_extra_kwargs=custom_template_variables, 
    ...,
)

...

```

Also see example in tests.