### PR TITLE
sec1: bump cryptography version to 38.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bsdiff4==1.2.2
 certifi==2022.9.24
 cffi==1.15.1
 charset-normalizer==2.1.1
-cryptography==38.0.1
+cryptography==38.0.3
 idna==3.4
 packaging==21.3
 pycparser==2.21

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     bsdiff4==1.2.*
+    cryptography>=38.0.3
     packaging==21.*
     securesystemslib[crypto,pynacl]==0.24.*
     setuptools>=61.*.*


### PR DESCRIPTION
bump cryptography version to fix OpenSSL security issue

https://cryptography.io/en/latest/changelog/#v38-0-3