### PR TITLE
Make patches optional

### DIFF
--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -703,15 +703,18 @@ class Repository(object):
             self,
             new_bundle_dir: Union[pathlib.Path, str],
             new_version: Optional[str] = None,
+            make_patch: bool = True,
     ):
         """
         Adds a new application bundle to the local repository.
 
         An archive file is created from the app bundle, and this file is
-        added to the tuf repository. If a previous archive version is
-        found, a patch file is also created and added to the repository.
+        added to the tuf repository. If a previous archive version is found,
+        a patch file is also created and added to the repository, unless
+        `make_patch` is False.
 
-        Note the changes are not published yet: call publish_changes() for that
+        Note the changes are not published yet: call `publish_changes()` for
+        that.
         """
         # enforce path object
         new_bundle_dir = pathlib.Path(new_bundle_dir)
@@ -734,7 +737,7 @@ class Repository(object):
             # register new archive
             self.roles.add_or_update_target(local_path=new_archive.path)
             # create patch, if possible, and register that too
-            if latest_archive:
+            if latest_archive and make_patch:
                 patch_path = Patcher.create_patch(
                     src_path=self.targets_dir / latest_archive.path,
                     dst_path=self.targets_dir / new_archive.path,

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -703,7 +703,7 @@ class Repository(object):
             self,
             new_bundle_dir: Union[pathlib.Path, str],
             new_version: Optional[str] = None,
-            make_patch: bool = True,
+            skip_patch: bool = False,
     ):
         """
         Adds a new application bundle to the local repository.
@@ -711,7 +711,7 @@ class Repository(object):
         An archive file is created from the app bundle, and this file is
         added to the tuf repository. If a previous archive version is found,
         a patch file is also created and added to the repository, unless
-        `make_patch` is False.
+        `skip_patch` is True.
 
         Note the changes are not published yet: call `publish_changes()` for
         that.
@@ -737,7 +737,7 @@ class Repository(object):
             # register new archive
             self.roles.add_or_update_target(local_path=new_archive.path)
             # create patch, if possible, and register that too
-            if latest_archive and make_patch:
+            if latest_archive and not skip_patch:
                 patch_path = Patcher.create_patch(
                     src_path=self.targets_dir / latest_archive.path,
                     dst_path=self.targets_dir / new_archive.path,

--- a/src/tufup/repo/cli.py
+++ b/src/tufup/repo/cli.py
@@ -19,6 +19,7 @@ HELP = dict(
     ),
     targets_add_app_version='Application version (PEP440 compliant)',
     targets_add_bundle_dir='Directory containing application bundle.',
+    targets_add_skip_patch='Skip patch creation.',
     targets_remove_latest='Remove latest app bundle from the repository.',
     keys_subcommands='Optional commands to add or replace keys.',
     keys_new_key_name='Name of new private key (public key gets .pub suffix).',
@@ -79,6 +80,13 @@ def get_parser() -> argparse.ArgumentParser:
     )
     subparser_targets_add.add_argument(
         'bundle_dir', help=HELP['targets_add_bundle_dir']
+    )
+    subparser_targets_add.add_argument(
+        '-s',
+        '--skip-patch',
+        action='store_true',
+        required=False,
+        help=HELP['targets_add_skip_patch'],
     )
     subparser_targets_remove = targets_subparsers.add_parser(
         'remove-latest', help=HELP['targets_remove_latest']
@@ -274,7 +282,9 @@ def _cmd_targets(options: argparse.Namespace):
     if hasattr(options, 'app_version') and hasattr(options, 'bundle_dir'):
         _print_info('Adding bundle...')
         repository.add_bundle(
-            new_version=options.app_version, new_bundle_dir=options.bundle_dir
+            new_version=options.app_version,
+            new_bundle_dir=options.bundle_dir,
+            make_patch=not options.skip_patch,
         )
     else:
         _print_info('Removing latest bundle...')

--- a/src/tufup/repo/cli.py
+++ b/src/tufup/repo/cli.py
@@ -284,7 +284,7 @@ def _cmd_targets(options: argparse.Namespace):
         repository.add_bundle(
             new_version=options.app_version,
             new_bundle_dir=options.bundle_dir,
-            make_patch=not options.skip_patch,
+            skip_patch=options.skip_patch,
         )
     else:
         _print_info('Removing latest bundle...')

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -696,7 +696,7 @@ class RepositoryTests(TempDirTestCase):
         # test
         bundle_file.write_text('much has changed in version 2')
         repo.add_bundle(
-            new_version='2.0', new_bundle_dir=bundle_dir, make_patch=False
+            new_version='2.0', new_bundle_dir=bundle_dir, skip_patch=True
         )
         self.assertTrue((repo.metadata_dir / 'targets.json').exists())
         target_keys = list(repo.roles.targets.signed.targets.keys())

--- a/tests/test_repo_cli.py
+++ b/tests/test_repo_cli.py
@@ -125,9 +125,7 @@ class CommandTests(TempDirTestCase):
         with patch('tufup.repo.cli.Repository', self.mock_repo_class):
             tufup.repo.cli._cmd_targets(options=options)
         self.mock_repo.add_bundle.assert_called_with(
-            new_version=version,
-            new_bundle_dir=bundle_dir,
-            make_patch= not skip_patch,
+            new_version=version, new_bundle_dir=bundle_dir, skip_patch=skip_patch,
         )
         self.mock_repo.publish_changes.assert_called_with(
             private_key_dirs=key_dirs

--- a/tests/test_repo_cli.py
+++ b/tests/test_repo_cli.py
@@ -16,6 +16,7 @@ class ParserTests(unittest.TestCase):
             'init --debug',
             'targets add 1.0 c:\\my_bundle_dir c:\\private_keys',
             'targets -d add 1.0 c:\\my_bundle_dir c:\\private_keys',
+            'targets -d add -s 1.0 c:\\my_bundle_dir c:\\private_keys',
             'targets remove-latest c:\\private_keys',
             'keys my-key-name -c -e',
             'keys my-key-name add root c:\\private_keys d:\\more_private_keys',
@@ -114,13 +115,19 @@ class CommandTests(TempDirTestCase):
         version = '1.0'
         bundle_dir = 'dummy'
         key_dirs = ['c:\\my_private_keys']
+        skip_patch = True
         options = argparse.Namespace(
-            app_version=version, bundle_dir=bundle_dir, key_dirs=key_dirs
+            app_version=version,
+            bundle_dir=bundle_dir,
+            key_dirs=key_dirs,
+            skip_patch=skip_patch,
         )
         with patch('tufup.repo.cli.Repository', self.mock_repo_class):
             tufup.repo.cli._cmd_targets(options=options)
         self.mock_repo.add_bundle.assert_called_with(
-            new_version=version, new_bundle_dir=bundle_dir
+            new_version=version,
+            new_bundle_dir=bundle_dir,
+            make_patch= not skip_patch,
         )
         self.mock_repo.publish_changes.assert_called_with(
             private_key_dirs=key_dirs


### PR DESCRIPTION
Patch creation can be time consuming. In some workflows, this is not desired. See e.g. #67.
 
For this reason, allowing users to skip patch creation sounds reasonable.

The following changes are made on the repo side:

- `Repository.add_bundle()` gets a `skip_patch` argument, which defaults to `False`
- the CLI command `tufup targets add` gets a `--skip-patch` (`-s`) option

The tufup `Client` should already know how to handle missing patches. 