### PR TITLE
Fix issue 50: use relative paths in config file

### DIFF
--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -585,9 +585,7 @@ class Repository(object):
                 )
         # write file
         config_file_path.write_text(
-            data=json.dumps(
-                temp_config_dict, default=str, sort_keys=True, indent=4
-            ),
+            data=json.dumps(temp_config_dict, default=str, sort_keys=True, indent=4),
             encoding='utf-8',
         )
 

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -36,6 +36,7 @@ from tuf.api.metadata import (
 from tuf.api.serialization.json import JSONSerializer
 
 from tufup.common import Patcher, SUFFIX_ARCHIVE, SUFFIX_PATCH, TargetMeta
+from tufup.utils.platform_specific import _patched_resolve
 
 logger = logging.getLogger(__name__)
 
@@ -515,9 +516,9 @@ class Repository(object):
             thresholds: Optional[RolesDict] = None,
     ):
         if repo_dir is None:
-            repo_dir = pathlib.Path.cwd() / DEFAULT_REPO_DIR_NAME
+            repo_dir = DEFAULT_REPO_DIR_NAME
         if keys_dir is None:
-            keys_dir = pathlib.Path.cwd() / DEFAULT_KEYS_DIR_NAME
+            keys_dir = DEFAULT_KEYS_DIR_NAME
         if key_map is None:
             key_map = deepcopy(DEFAULT_KEY_MAP)
         if encrypted_keys is None:
@@ -529,8 +530,8 @@ class Repository(object):
         self.app_name = app_name
         self.app_version_attr = app_version_attr
         # force path object and resolve, in case of relative paths
-        self.repo_dir = pathlib.Path(repo_dir).resolve()
-        self.keys_dir = pathlib.Path(keys_dir).resolve()
+        self.repo_dir = _patched_resolve(pathlib.Path(repo_dir))
+        self.keys_dir = _patched_resolve(pathlib.Path(keys_dir))
         self.key_map = key_map
         self.encrypted_keys = encrypted_keys
         self.expiration_days = expiration_days

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -580,12 +580,17 @@ class Repository(object):
         for key in ['repo_dir', 'keys_dir']:
             try:
                 temp_config_dict[key] = temp_config_dict[key].relative_to(
-                    pathlib.Path.cwd()
+                    # resolve() is necessary on windows, to handle "short"
+                    # path components (a.k.a. "8.3 filename" or "8.3 alias"),
+                    # which are truncated with a tilde,
+                    # e.g. c:\Users\RUNNER~1\...
+                    pathlib.Path.cwd().resolve()
                 )
             except ValueError:
                 logger.warning(
-                    f'Saving *absolute* path in config, because the path is'
-                    f' not relative to cwd: {temp_config_dict[key]}'
+                    f'Saving *absolute* path to config, because the path'
+                    f' ({temp_config_dict[key]}) is not relative to cwd'
+                    f' ({pathlib.Path.cwd()})'
                 )
         # write file
         config_file_path.write_text(

--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -240,3 +240,20 @@ def _install_update_mac(
     logger.debug(f'Restarting application, running {sys.executable}.')
     subprocess.Popen(sys.executable, shell=True)  # nosec
     sys.exit(0)
+
+
+def _patched_resolve(path: pathlib.Path):
+    """
+    this is a rather crude workaround for cpython issue #82852,
+    where Path.resolve() yields a relative path, on windows, if the target
+    does not exist yet
+
+    https://github.com/python/cpython/issues/82852
+
+    todo: remove this as soon as support for python 3.9 is dropped
+    """
+    if ON_WINDOWS and sys.version_info[:2] < (3, 10):
+        logger.warning('using patched path for cpython #82852')
+        if not path.is_absolute():
+            path = pathlib.Path.cwd() / path
+    return path.resolve()

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -527,7 +527,15 @@ class RepositoryTests(TempDirTestCase):
         # test
         repo.save_config()
         self.assertTrue(repo.get_config_file_path().exists())
-        print(repo.get_config_file_path().read_text())
+        config_file_text = repo.get_config_file_path().read_text()
+        print(config_file_text)  # for convenience
+        # paths saved to config file must be relative (note that we should
+        # still be able to *read* absolute paths from the config file)
+        config_dict = json.loads(config_file_text)
+        for key in ['repo_dir', 'keys_dir']:
+            with self.subTest(msg=key):
+                # note Path.is_relative_to() is introduced in python 3.9
+                self.assertFalse(pathlib.Path(config_dict[key]).is_absolute())
 
     def test_load_config(self):
         # file does not exist

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -529,8 +529,8 @@ class RepositoryTests(TempDirTestCase):
         self.assertTrue(repo.get_config_file_path().exists())
         config_file_text = repo.get_config_file_path().read_text()
         print(config_file_text)  # for convenience
-        # paths saved to config file must be relative (note that we should
-        # still be able to *read* absolute paths from the config file)
+        # paths saved to config file are relative to current working
+        # directory (cwd) if possible (otherwise absolute paths are saved)
         config_dict = json.loads(config_file_text)
         for key in ['repo_dir', 'keys_dir']:
             with self.subTest(msg=key):

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -485,9 +485,7 @@ class RepositoryTests(TempDirTestCase):
         ]
         for message, repo_dir, keys_dir in cases:
             with self.subTest(msg=message):
-                repo = Repository(
-                    app_name='test', repo_dir=repo_dir, keys_dir=keys_dir
-                )
+                repo = Repository(app_name='test', repo_dir=repo_dir, keys_dir=keys_dir)
                 # internally we should always have the absolute paths
                 self.assertTrue(repo.repo_dir.is_absolute())
                 self.assertTrue(repo.keys_dir.is_absolute())
@@ -553,7 +551,11 @@ class RepositoryTests(TempDirTestCase):
         keys_dir_abs = temp_dir / 'keystore'
         cases = [
             ('absolute paths', repo_dir_abs, keys_dir_abs),
-            ('relative paths', repo_dir_abs.relative_to(temp_dir), keys_dir_abs.relative_to(temp_dir)),
+            (
+                'relative paths',
+                repo_dir_abs.relative_to(temp_dir),
+                keys_dir_abs.relative_to(temp_dir),
+            ),
         ]
         for message, repo_dir, keys_dir in cases:
             with self.subTest(msg=message):

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -492,8 +492,13 @@ class RepositoryTests(TempDirTestCase):
                     app_name='test', repo_dir=repo_dir, keys_dir=keys_dir
                 )
                 # internally we should always have the absolute paths
-                self.assertEqual(repo_dir_abs, repo.repo_dir)
-                self.assertEqual(keys_dir_abs, repo.keys_dir)
+                self.assertTrue(repo.repo_dir.is_absolute())
+                self.assertTrue(repo.keys_dir.is_absolute())
+                # compare dirs
+                # resolve is necessary for github actions, see:
+                # https://github.com/actions/runner-images/issues/712#issuecomment-1163036706
+                self.assertEqual(repo_dir_abs.resolve(), repo.repo_dir.resolve())
+                self.assertEqual(keys_dir_abs.resolve(), repo.keys_dir.resolve())
 
     def test_config_dict(self):
         app_name = 'test'

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -475,6 +475,26 @@ class RepositoryTests(TempDirTestCase):
     def test_defaults(self):
         self.assertTrue(Repository(app_name='test'))
 
+    def test_init_paths(self):
+        repo_dir_name = 'repo'
+        keys_dir_name = 'keystore'
+        # absolute paths (could also use resolve on relative path...)
+        repo_dir_abs = self.temp_dir_path / repo_dir_name
+        keys_dir_abs = self.temp_dir_path / keys_dir_name
+        cases = [
+            ('string', repo_dir_name, keys_dir_name),
+            ('relative', pathlib.Path(repo_dir_name), pathlib.Path(keys_dir_name)),
+            ('absolute', repo_dir_abs, keys_dir_abs),
+        ]
+        for message, repo_dir, keys_dir in cases:
+            with self.subTest(msg=message):
+                repo = Repository(
+                    app_name='test', repo_dir=repo_dir, keys_dir=keys_dir
+                )
+                # internally we should always have the absolute paths
+                self.assertEqual(repo_dir_abs, repo.repo_dir)
+                self.assertEqual(keys_dir_abs, repo.keys_dir)
+
     def test_config_dict(self):
         app_name = 'test'
         repo = Repository(app_name=app_name)


### PR DESCRIPTION
Use relative paths (i.e. relative to current working directory) for `repo_dir` and `keys_dir` in config file, if possible.
The config file itself is also in cwd.

Fixes #50