### PR TITLE
add optional process_creation_flags argument to _install_update_win()

### DIFF
--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -218,6 +218,8 @@ def _install_update_win(
         # using the process_creation_flags argument
         if process_creation_flags is None:
             process_creation_flags = subprocess.CREATE_NEW_CONSOLE
+        else:
+            logger.debug('using custom process creation flags')
         # we use Popen() instead of run(), because the latter blocks execution
         subprocess.Popen([script_path], creationflags=process_creation_flags)
     logger.debug('exiting')

--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -128,6 +128,7 @@ def _install_update_win(
     batch_template_extra_kwargs: Optional[dict] = None,
     log_file_name: Optional[str] = None,
     robocopy_options_override: Optional[List[str]] = None,
+    process_creation_flags = None,
 ):
     """
     Create a batch script that moves files from src to dst, then run the
@@ -159,7 +160,14 @@ def _install_update_win(
     to be overridden completely. It accepts a list of option strings. This
     will cause the purge arguments to be ignored as well.
 
+    The `process_creation_flags` option allows users to override creation flags for
+    the subprocess call that runs the batch script. For example, one could specify
+    `subprocess.CREATE_NO_WINDOW` to prevent a window from opening. See [2] and [3]
+    for details.
+
     [1]: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy
+    [2]: https://docs.python.org/3/library/subprocess.html#windows-constants
+    [3]: https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
     """
     if batch_template_extra_kwargs is None:
         batch_template_extra_kwargs = dict()
@@ -206,8 +214,12 @@ def _install_update_win(
     if as_admin:
         run_bat_as_admin(file_path=script_path)
     else:
+        # by default we create a new console with window, but user can override this
+        # using the process_creation_flags argument
+        if process_creation_flags is None:
+            process_creation_flags = subprocess.CREATE_NEW_CONSOLE
         # we use Popen() instead of run(), because the latter blocks execution
-        subprocess.Popen([script_path], creationflags=subprocess.CREATE_NEW_CONSOLE)
+        subprocess.Popen([script_path], creationflags=process_creation_flags)
     logger.debug('exiting')
     # exit current process
     sys.exit(0)

--- a/tests/test_utils_platform_specific.py
+++ b/tests/test_utils_platform_specific.py
@@ -22,6 +22,7 @@ _reason_platform_not_supported = (
 )
 
 DUMMY_APP_CONTENT = f"""
+import subprocess
 import sys
 sys.path.append('{(BASE_DIR.parent / 'src').as_posix()}')
 from tufup.utils.platform_specific import install_update
@@ -175,6 +176,22 @@ class UtilsTests(TempDirTestCase):
         self.assertTrue(log_file_path.exists())
         log_file_content = log_file_path.read_text()
         self.assertTrue(log_file_content)
+
+    @unittest.skipIf(
+        condition=not ON_WINDOWS, reason='process_creation_flags is for windows only'
+    )
+    def test_install_update_process_creation_flags(self):
+        # the log file is only used to verify that the batch file has run successfully
+        log_file_name = 'install.log'
+        extra_kwargs_strings = [
+            'process_creation_flags=subprocess.CREATE_NO_WINDOW',
+            f'log_file_name="{log_file_name}"',
+        ]
+        # run the dummy app in a separate process
+        self.run_dummy_app(extra_kwargs_strings=extra_kwargs_strings)
+        # a log file should exist
+        log_file_path = self.dst_dir / log_file_name
+        self.assertTrue(log_file_path.read_text())
 
     @unittest.skipIf(
         condition=not ON_WINDOWS, reason='windows batch files are windows only'


### PR DESCRIPTION
The optional `process_creation_flags` argument allows users to override the [process creation flags][2] used for the subprocess call that runs the windows batch script that does the actual installation (i.e. moving files into place). 

The `process_creation_flags` argument accepts [subprocess Windows constants][1].

The default value remains `subprocess.CREATE_NEW_CONSOLE`, as before.

Usage example: 

```python
client.download_and_apply_update(..., process_creation_flags=subprocess.CREATE_NO_WINDOW)
```

fixes #81

[1]: https://docs.python.org/3/library/subprocess.html#windows-constants
[2]: https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags