### PR TITLE
add purge_extract_dir option to Client

### DIFF
--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -128,7 +128,7 @@ def _install_update_win(
     batch_template_extra_kwargs: Optional[dict] = None,
     log_file_name: Optional[str] = None,
     robocopy_options_override: Optional[List[str]] = None,
-    process_creation_flags = None,
+    process_creation_flags=None,
 ):
     """
     Create a batch script that moves files from src to dst, then run the


### PR DESCRIPTION
This uses a `purge.manifest` file to prevent accidental deletion of unrelated files...

Note: Perhaps this is too complicated? Should we simply rely on a namespaced `extract_dir`?

fixes #56