### PR TITLE
Fail-safe mechanism for patch updates

### DIFF
--- a/src/tufup/client.py
+++ b/src/tufup/client.py
@@ -1,4 +1,4 @@
-import bsdiff4
+from copy import deepcopy
 import logging
 import pathlib
 import shutil
@@ -7,6 +7,7 @@ import tempfile
 from typing import Callable, Dict, Iterator, List, Optional, Tuple, Union
 from urllib import parse
 
+import bsdiff4
 import requests
 from requests.auth import AuthBase
 from tuf.api.exceptions import DownloadError, UnsignedMetadataError
@@ -18,6 +19,7 @@ from tufup.utils.platform_specific import install_update
 logger = logging.getLogger(__name__)
 
 DEFAULT_EXTRACT_DIR = pathlib.Path(tempfile.gettempdir()) / 'tufup'
+SUFFIX_FAILED = '.failed'
 
 
 class Client(tuf.ngclient.Updater):
@@ -194,17 +196,27 @@ class Client(tuf.ngclient.Updater):
             total_patch_size = sum(
                 target_file.length for target_file in new_patches.values()
             )
+            # abort patch update if any of the new patches have failed on a previous run
+            abort_patch = False
+            for patch_info in new_patches.values():
+                patch_info_mod = deepcopy(patch_info)  # modify a copy, just to be sure
+                patch_info_mod.path += SUFFIX_FAILED
+                if self.find_cached_target(targetinfo=patch_info_mod):
+                    logger.debug(f'aborting patch due to {patch_info_mod.path}')
+                    abort_patch = True
             # use file size to decide if we want to do a patch update or a
             # full update (if there are no patches, or if the current archive
             # is not available, we must do a full update)
             self.new_targets = new_patches
             no_patches = total_patch_size == 0
-            patches_too_big = total_patch_size > self.new_archive_info.length
-            current_archive_not_found = not self.current_archive_local_path.exists()
-            if not patch or no_patches or patches_too_big or current_archive_not_found:
+            patch_too_big = total_patch_size > self.new_archive_info.length
+            no_archive = not self.current_archive_local_path.exists()
+            if not patch or no_patches or patch_too_big or no_archive or abort_patch:
+                # fall back on full update
                 self.new_targets = {new_archive_meta: self.new_archive_info}
                 logger.debug('full update available')
             else:
+                # continue with patch update
                 logger.debug('patch update(s) available')
         else:
             self.new_targets = {}

--- a/src/tufup/client.py
+++ b/src/tufup/client.py
@@ -273,7 +273,7 @@ class Client(tuf.ngclient.Updater):
                 # write the patched new archive
                 self.new_archive_local_path.write_bytes(archive_bytes)
         except Exception as e:
-            if target and file_path:
+            if target and file_path and file_path.exists():
                 renamed_path = file_path.replace(
                     file_path.with_suffix(file_path.suffix + SUFFIX_FAILED)
                 )

--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -128,7 +128,7 @@ def _install_update_win(
     batch_template_extra_kwargs: Optional[dict] = None,
     log_file_name: Optional[str] = None,
     robocopy_options_override: Optional[List[str]] = None,
-    process_creation_flags = None,
+    process_creation_flags=None,
 ):
     """
     Create a batch script that moves files from src to dst, then run the

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -254,9 +254,9 @@ class ClientTests(TempDirTestCase):
         with self.subTest(msg='patch failure due to mismatch'):
             mock_install = Mock()
             with patch.object(
-                    client.new_archive_info,
-                    'verify_length_and_hashes',
-                    Mock(side_effect=LengthOrHashMismatchError()),
+                client.new_archive_info,
+                'verify_length_and_hashes',
+                Mock(side_effect=LengthOrHashMismatchError()),
             ):
                 client._apply_updates(install=mock_install, skip_confirmation=True)
             mock_install.assert_not_called()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -263,9 +263,6 @@ class ClientTests(TempDirTestCase):
             target_paths = pathlib.Path(client.target_dir).iterdir()
             self.assertTrue(any(path.suffix == SUFFIX_FAILED for path in target_paths))
 
-    def test__apply_updates_failed(self):
-        client = self.get_refreshed_client()
-
     def test_version_comparison(self):
         # verify assumed version hierarchy
         v = packaging.version.Version


### PR DESCRIPTION
If a patch fails, for whatever reason, the downloaded patch file is flagged with a `.failed` suffix.

The client then continues without updating.

On the next run, the failed patch will be ignored, and a full update is downloaded instead.

fixes #98