### PR TITLE
Improved key-finding ability for Repository.initialize

### DIFF
--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -626,7 +626,7 @@ class Repository(object):
         instance._load_keys_and_roles(create_keys=False)
         return instance
 
-    def initialize(self, extra_key_dirs: Optional[list[pathlib.Path]] = None):
+    def initialize(self, extra_key_dirs: Optional[List[pathlib.Path]] = None):
         """
         Initialize (or update) the local repository.
 

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -260,16 +260,28 @@ class Keys(Base):
         return roles_map
 
     @classmethod
-    def find_private_key(cls, key_name: str, key_dirs: List[Union[pathlib.Path, str]]):
-        private_key_path = None
+    def find_private_key(
+        cls, key_name: str, key_dirs: List[Union[pathlib.Path, str]]
+    ) -> Optional[pathlib.Path]:
+        """
+        recursively search key_dirs for a private key with specified key_name
+
+        returns path to first matching file (or None)
+        """
         private_key_filename = cls.filename_pattern.format(key_name=key_name)
         for key_dir in key_dirs:
             key_dir = pathlib.Path(key_dir)  # ensure Path
             for path in key_dir.iterdir():
                 if path.is_file() and path.name == private_key_filename:
-                    private_key_path = path
-                    break
-        return private_key_path
+                    # base case
+                    return path
+                elif path.is_dir():
+                    # recursive case
+                    private_key_path = cls.find_private_key(
+                        key_name=key_name, key_dirs=[path]
+                    )
+                    if private_key_path:
+                        return private_key_path
 
 
 class Roles(Base):

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -614,7 +614,7 @@ class Repository(object):
         instance._load_keys_and_roles(create_keys=False)
         return instance
 
-    def initialize(self):
+    def initialize(self, extra_key_dirs: Optional[list[pathlib.Path]] = None):
         """
         Initialize (or update) the local repository.
 
@@ -627,6 +627,8 @@ class Repository(object):
 
         Safe to call for existing keys and roles.
         """
+        extra_key_dirs = extra_key_dirs or []
+
         # Ensure dirs exist
         for path in [self.keys_dir, self.metadata_dir, self.targets_dir]:
             path.mkdir(parents=True, exist_ok=True)
@@ -636,7 +638,7 @@ class Repository(object):
 
         # Publish root metadata (save 1.root.json and copy to root.json)
         if not self.roles.file_path('root').exists():
-            self.publish_changes(private_key_dirs=[self.keys_dir])
+            self.publish_changes(private_key_dirs=[self.keys_dir] + extra_key_dirs)
 
     def refresh_expiration_date(self, role_name: str, days: Optional[int] = None):
         if days is None:

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -257,21 +257,22 @@ class KeysTests(TempDirTestCase):
         # create dummy private key files in separate folders
         key_names = [
             ('online', [Snapshot.type, Timestamp.type]),
-            ('offline', [Root.type, Targets.type]),
+            ('offline/subdir', [Root.type, Targets.type]),  # subdir tests recursion
         ]
-        key_dirs = []
         for dir_name, role_names in key_names:
             dir_path = self.temp_dir_path / dir_name
-            dir_path.mkdir()
-            key_dirs.append(dir_path)
+            dir_path.mkdir(parents=True)
             for role_name in role_names:
                 filename = Keys.filename_pattern.format(key_name=role_name)
                 (dir_path / filename).touch()
         # test
+        key_dirs = list(self.temp_dir_path.iterdir())  # ['online', 'offline']
         for role_name in TOP_LEVEL_ROLE_NAMES:
             key_path = Keys.find_private_key(key_name=role_name, key_dirs=key_dirs)
+            self.assertTrue(key_path)
             self.assertIn(role_name, str(key_path))
             self.assertTrue(key_path.exists())
+        self.assertIsNone(Keys.find_private_key(key_name='missing', key_dirs=key_dirs))
 
 
 class RolesTests(TempDirTestCase):


### PR DESCRIPTION
- `Keys.find_private_key()` is now recursive, i.e. it searches subdirectories as well
- `Repository.initialize()` has an optional `extra_key_dirs` argument

fixes #102