### PR TITLE
Simplified interface for custom metadata

### DIFF
--- a/examples/repo/repo_workflow_example.py
+++ b/examples/repo/repo_workflow_example.py
@@ -55,9 +55,9 @@ TARGETS_DIR = REPO_DIR / DEFAULT_TARGETS_DIR_NAME
 # This script is also used to create/update test data, in which case we need to
 # override some variables. Everything related to _UPDATE_TEST_DATA can be ignored for
 # normal use.
-_UPDATE_TEST_DATA = int(os.getenv('UPDATE_TEST_DATA', 0))
+_UPDATE_TEST_DATA = os.getenv('UPDATE_TEST_DATA')
 TEST_DATA_EXPIRATION_DAYS = None
-if _UPDATE_TEST_DATA:
+if _UPDATE_TEST_DATA is not None:
     TEST_DATA_EXPIRATION_DAYS = 10000
     PROJECT_DIR = BASE_DIR.parent.parent
     TEST_DATA_DIR = PROJECT_DIR / 'tests' / 'data'
@@ -66,7 +66,10 @@ if _UPDATE_TEST_DATA:
     TARGETS_DIR = REPO_DIR / DEFAULT_TARGETS_DIR_NAME
     logger.warning(f'updating test data in {TEST_DATA_DIR}')
     # start with clean slate
-    for dir_path in [META_DIR, TARGETS_DIR]:
+    dirs_to_clean = dict(
+        metadata=[META_DIR], targets=[TARGETS_DIR], all=[META_DIR, TARGETS_DIR]
+    )
+    for dir_path in dirs_to_clean.get(_UPDATE_TEST_DATA, []):
         for path in dir_path.iterdir():
             if path.suffix in ['.gz', '.patch', '.json']:
                 path.unlink()

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -728,8 +728,7 @@ class Repository(object):
         new_bundle_dir: Union[pathlib.Path, str],
         new_version: Optional[str] = None,
         skip_patch: bool = False,
-        custom_metadata_for_archive: Optional[dict] = None,
-        custom_metadata_for_patch: Optional[dict] = None,
+        custom_metadata: Optional[dict] = None,  # archive only
     ):
         """
         Adds a new application bundle to the local repository.
@@ -762,7 +761,7 @@ class Repository(object):
         if not latest_archive or latest_archive.version < new_archive.version:
             # register new archive
             self.roles.add_or_update_target(
-                local_path=new_archive.path, custom=custom_metadata_for_archive
+                local_path=new_archive.path, custom=custom_metadata
             )
             # create patch, if possible, and register that too
             if latest_archive and not skip_patch:
@@ -770,9 +769,7 @@ class Repository(object):
                     src_path=self.targets_dir / latest_archive.path,
                     dst_path=self.targets_dir / new_archive.path,
                 )
-                self.roles.add_or_update_target(
-                    local_path=patch_path, custom=custom_metadata_for_patch
-                )
+                self.roles.add_or_update_target(local_path=patch_path)
 
     def remove_latest_bundle(self):
         """

--- a/tests/data/keystore/offline_secrets_1/root
+++ b/tests/data/keystore/offline_secrets_1/root
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid": "b7ad916e4138911155b771d0ede66666e9647e7fb6c85a1904be97dee5653568", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "4cec23f563ae4d97e22c823ed8c3c2effed9ca568fab68179f0a338526003813", "private": "aad6a081d799da1b05ba8caed5bb5af28b4c27323fbce91dae4d0f4576fba041"}}

--- a/tests/data/keystore/offline_secrets_1/targets
+++ b/tests/data/keystore/offline_secrets_1/targets
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid": "cd9930c92ac25c02a2f92ae3128b50459b53d7532ef9c0f364e78f388d5808a5", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "6849e4a7ca3e121cce7368dc939419fd2de031f4f33fc86083ff1bed4db8403a", "private": "2dc257cdcc46987b204365569a773e7937c53cd37df60fbc23e86fac01aef424"}}

--- a/tests/data/keystore/offline_secrets_2/root_three
+++ b/tests/data/keystore/offline_secrets_2/root_three
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid": "1bd53d9d6f08f6efba19477880b348906f5f29a67d78cbca8a44aedfad12d003", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "b64b98945cc9e4c0997a896e3856f3198309d369ed2c54d59a7193ac63a40854", "private": "e9faa5edf1a174fb33cb6f2fc206af95e7a5c40dcade96053f79e445f26ccce1"}}

--- a/tests/data/keystore/offline_secrets_2/root_three.pub
+++ b/tests/data/keystore/offline_secrets_2/root_three.pub
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "b64b98945cc9e4c0997a896e3856f3198309d369ed2c54d59a7193ac63a40854"}}

--- a/tests/data/keystore/offline_secrets_2/root_two
+++ b/tests/data/keystore/offline_secrets_2/root_two
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid": "d4ec748f9476f9f7e1f0a247b917dde4abe8a024de9ba34c7458b41bec8be6b2", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "4e156bc0a9ba4cce79cd53405d597a906f70e6b4a737c96b21fb69ca8d0c0efc", "private": "4530c21c6bdc83c2f5d2dbd401b5745c93cb7bd40d344c7b8053e43b127bb06a"}}

--- a/tests/data/keystore/online_secrets/snapshot
+++ b/tests/data/keystore/online_secrets/snapshot
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid": "5ef48ab6f5398d2bf17f1f4c4fc0e0440c4aa3734a05ae523561e02e8a99957a", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "98dfc1375ce8818259ba23aa24bb596d6a60026e555285baccc1d3524677bcfe", "private": "67dd8d2478ebf07e26a942728d956c2453be98196f9f701a9b4f24eae6e5d23b"}}

--- a/tests/data/keystore/online_secrets/timestamp
+++ b/tests/data/keystore/online_secrets/timestamp
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid": "eddb87d254d513c1404d71e17620ecf5260e1836babdaa55197916c582f37a00", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "6479fe966d5b5fb11d3339c18b42235bbe2a49e54966d6d1bc6a79e7985aedf8", "private": "0538bb26a32387c00775f6b1f980ffe56d6b069faebb95d8f5bc1cf80a970bb7"}}

--- a/tests/data/keystore/root.pub
+++ b/tests/data/keystore/root.pub
@@ -1,1 +1,0 @@
-{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "f5033e2659886185ceedec69e2cfee0f348ea63dfffafd5f8566d001b45c470d"}}

--- a/tests/data/keystore/root.pub
+++ b/tests/data/keystore/root.pub
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "4cec23f563ae4d97e22c823ed8c3c2effed9ca568fab68179f0a338526003813"}}

--- a/tests/data/keystore/root_two.pub
+++ b/tests/data/keystore/root_two.pub
@@ -1,1 +1,0 @@
-{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "c8eaa5bf0f26e7247c965388a7ce7d3a25113899139c3d9bd2dbbb5e95577397"}}

--- a/tests/data/keystore/root_two.pub
+++ b/tests/data/keystore/root_two.pub
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "4e156bc0a9ba4cce79cd53405d597a906f70e6b4a737c96b21fb69ca8d0c0efc"}}

--- a/tests/data/keystore/snapshot.pub
+++ b/tests/data/keystore/snapshot.pub
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "98dfc1375ce8818259ba23aa24bb596d6a60026e555285baccc1d3524677bcfe"}}

--- a/tests/data/keystore/snapshot.pub
+++ b/tests/data/keystore/snapshot.pub
@@ -1,1 +1,0 @@
-{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "41bf1adabf1f564de734fa5fb584a65b943317978a4dcbe39bab03ee722ee73f"}}

--- a/tests/data/keystore/targets.pub
+++ b/tests/data/keystore/targets.pub
@@ -1,1 +1,0 @@
-{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "a27a0209711787a4227cbfed23735a75b5f7f5cb0cd6acbf7a239fa2c3535434"}}

--- a/tests/data/keystore/targets.pub
+++ b/tests/data/keystore/targets.pub
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "6849e4a7ca3e121cce7368dc939419fd2de031f4f33fc86083ff1bed4db8403a"}}

--- a/tests/data/keystore/timestamp.pub
+++ b/tests/data/keystore/timestamp.pub
@@ -1,1 +1,0 @@
-{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "2ec5e87c77fe70d918d92a1d849f4ec12907a34cf208123bbbc6d1e4bd584885"}}

--- a/tests/data/keystore/timestamp.pub
+++ b/tests/data/keystore/timestamp.pub
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "6479fe966d5b5fb11d3339c18b42235bbe2a49e54966d6d1bc6a79e7985aedf8"}}

--- a/tests/data/repository/metadata/1.root.json
+++ b/tests/data/repository/metadata/1.root.json
@@ -1,51 +1,51 @@
 {
  "signatures": [
   {
-   "keyid": "104c43225506bf7637a0061775a0d23ca8693e6bb4b270bc9ee9664259eb77d8",
-   "sig": "aa37e6a5e46938eb7c72054f2f2ff929e949283be67149c2a4fe481e51b91d8cc16876cbce03619af1d0b331ebf1d72ec368069ca49cca8d95a96eeaa06bfc07"
+   "keyid": "b7ad916e4138911155b771d0ede66666e9647e7fb6c85a1904be97dee5653568",
+   "sig": "8582f12a66a923c8069a4385ef594c345ca2bd69741c0ba2691c4cb20e005e7a771f6ca651852d1264d13107d108c5843d3f9b69bcd20500f7108cca6e6c8901"
   },
   {
-   "keyid": "eb456bc4372b9aef1aea4790911d748a741d27ad0bd0eabcfe41e7fe3c6e9a8f",
-   "sig": "b70196c013a883d0ae5fede183e1c49556ee26fecb0798968e41a391121c39ab229ed2e1f7067760232aeac0b709ecf48a29df34f0184349c5d96f4e9be91703"
+   "keyid": "d4ec748f9476f9f7e1f0a247b917dde4abe8a024de9ba34c7458b41bec8be6b2",
+   "sig": "3f2a6d6cd8232d0ca1f2b75445a7dc9bc4342f72fe88204fac7e7acad48eb6102ff1ba4b1efaf8f8ec32ee11cf68a5f92e34300f66b37e5970e878f77b2e9c0b"
   }
  ],
  "signed": {
   "_type": "root",
   "consistent_snapshot": false,
-  "expires": "2051-06-24T09:37:39Z",
+  "expires": "2051-06-25T13:08:41Z",
   "keys": {
-   "0eb56770be481c3a117f0487e7b6762edd0eaac7860ba85530dba400edf7de03": {
+   "5ef48ab6f5398d2bf17f1f4c4fc0e0440c4aa3734a05ae523561e02e8a99957a": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "2ec5e87c77fe70d918d92a1d849f4ec12907a34cf208123bbbc6d1e4bd584885"
+     "public": "98dfc1375ce8818259ba23aa24bb596d6a60026e555285baccc1d3524677bcfe"
     },
     "scheme": "ed25519"
    },
-   "104c43225506bf7637a0061775a0d23ca8693e6bb4b270bc9ee9664259eb77d8": {
+   "b7ad916e4138911155b771d0ede66666e9647e7fb6c85a1904be97dee5653568": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "c8eaa5bf0f26e7247c965388a7ce7d3a25113899139c3d9bd2dbbb5e95577397"
+     "public": "4cec23f563ae4d97e22c823ed8c3c2effed9ca568fab68179f0a338526003813"
     },
     "scheme": "ed25519"
    },
-   "3515ef592c09ddb3a09da0096802afc26852dc7a1978cb1c99fbe3a6f5c0c1a1": {
+   "cd9930c92ac25c02a2f92ae3128b50459b53d7532ef9c0f364e78f388d5808a5": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "a27a0209711787a4227cbfed23735a75b5f7f5cb0cd6acbf7a239fa2c3535434"
+     "public": "6849e4a7ca3e121cce7368dc939419fd2de031f4f33fc86083ff1bed4db8403a"
     },
     "scheme": "ed25519"
    },
-   "5fcbe7c4faa87ab25bea551c0c4b0ac6e47a07caf5e7633314a784c54ad2ea8a": {
+   "d4ec748f9476f9f7e1f0a247b917dde4abe8a024de9ba34c7458b41bec8be6b2": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "41bf1adabf1f564de734fa5fb584a65b943317978a4dcbe39bab03ee722ee73f"
+     "public": "4e156bc0a9ba4cce79cd53405d597a906f70e6b4a737c96b21fb69ca8d0c0efc"
     },
     "scheme": "ed25519"
    },
-   "eb456bc4372b9aef1aea4790911d748a741d27ad0bd0eabcfe41e7fe3c6e9a8f": {
+   "eddb87d254d513c1404d71e17620ecf5260e1836babdaa55197916c582f37a00": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "f5033e2659886185ceedec69e2cfee0f348ea63dfffafd5f8566d001b45c470d"
+     "public": "6479fe966d5b5fb11d3339c18b42235bbe2a49e54966d6d1bc6a79e7985aedf8"
     },
     "scheme": "ed25519"
    }
@@ -53,26 +53,26 @@
   "roles": {
    "root": {
     "keyids": [
-     "eb456bc4372b9aef1aea4790911d748a741d27ad0bd0eabcfe41e7fe3c6e9a8f",
-     "104c43225506bf7637a0061775a0d23ca8693e6bb4b270bc9ee9664259eb77d8"
+     "d4ec748f9476f9f7e1f0a247b917dde4abe8a024de9ba34c7458b41bec8be6b2",
+     "b7ad916e4138911155b771d0ede66666e9647e7fb6c85a1904be97dee5653568"
     ],
     "threshold": 2
    },
    "snapshot": {
     "keyids": [
-     "5fcbe7c4faa87ab25bea551c0c4b0ac6e47a07caf5e7633314a784c54ad2ea8a"
+     "5ef48ab6f5398d2bf17f1f4c4fc0e0440c4aa3734a05ae523561e02e8a99957a"
     ],
     "threshold": 1
    },
    "targets": {
     "keyids": [
-     "3515ef592c09ddb3a09da0096802afc26852dc7a1978cb1c99fbe3a6f5c0c1a1"
+     "cd9930c92ac25c02a2f92ae3128b50459b53d7532ef9c0f364e78f388d5808a5"
     ],
     "threshold": 1
    },
    "timestamp": {
     "keyids": [
-     "0eb56770be481c3a117f0487e7b6762edd0eaac7860ba85530dba400edf7de03"
+     "eddb87d254d513c1404d71e17620ecf5260e1836babdaa55197916c582f37a00"
     ],
     "threshold": 1
    }

--- a/tests/data/repository/metadata/2.root.json
+++ b/tests/data/repository/metadata/2.root.json
@@ -1,55 +1,55 @@
 {
  "signatures": [
   {
-   "keyid": "104c43225506bf7637a0061775a0d23ca8693e6bb4b270bc9ee9664259eb77d8",
-   "sig": "629f1d19e28f6a217b728509222b565ca7168be8cc094fed2e9c547c35da39b127b9914b49628789abef754d0615147aada1377af2fc6355ff49a42f31253e0a"
+   "keyid": "b7ad916e4138911155b771d0ede66666e9647e7fb6c85a1904be97dee5653568",
+   "sig": "740d4c6945050abd3abba7023cb5128a4e344e83ae0f52f9c978b7b3582dd21213e72a66dec6cd4206093c634cb973cf3ec0940103e54e6a81c4424322cf2d01"
   },
   {
-   "keyid": "eb456bc4372b9aef1aea4790911d748a741d27ad0bd0eabcfe41e7fe3c6e9a8f",
-   "sig": "05cd311026a0e5cece1d6d54b6b7f957f4824a704b7a319619621448a9ccb65ad9b1068429cf813aace000887eacf7a20000bacbc52777c9b11e9641d6f78f0c"
+   "keyid": "1bd53d9d6f08f6efba19477880b348906f5f29a67d78cbca8a44aedfad12d003",
+   "sig": "58ed242676830567413936feec20c80cd79d03fc31bdad38ffd0ef69e40298dfd8fe15edb7a4fd504a01ee5a7cddd3bfbd169ccd9bd2c6067e452aeee3a18102"
   },
   {
-   "keyid": "1784b06ef8e18f906f3fd62f2fd81aa088bb58317da624e10b5a3ecb72bd662f",
-   "sig": "933b34c60eeca55793e875e45993397ec2447608c3d73777f6e20b452223ab949a4c1c2b0e9a9f2374bd7ac9cdc06f397407320b1039ff256e21ea52500a6106"
+   "keyid": "d4ec748f9476f9f7e1f0a247b917dde4abe8a024de9ba34c7458b41bec8be6b2",
+   "sig": "7ea041490934e6637998eb22ab367f1d260b3d0cdde144cc5a776dda7a65c27a6061d1b62986851ecbc49ad04c7a428987b323c1c961f65f8e0143c792deb706"
   }
  ],
  "signed": {
   "_type": "root",
   "consistent_snapshot": false,
-  "expires": "2051-06-24T09:37:39Z",
+  "expires": "2051-06-25T13:08:48Z",
   "keys": {
-   "0eb56770be481c3a117f0487e7b6762edd0eaac7860ba85530dba400edf7de03": {
+   "1bd53d9d6f08f6efba19477880b348906f5f29a67d78cbca8a44aedfad12d003": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "2ec5e87c77fe70d918d92a1d849f4ec12907a34cf208123bbbc6d1e4bd584885"
+     "public": "b64b98945cc9e4c0997a896e3856f3198309d369ed2c54d59a7193ac63a40854"
     },
     "scheme": "ed25519"
    },
-   "1784b06ef8e18f906f3fd62f2fd81aa088bb58317da624e10b5a3ecb72bd662f": {
+   "5ef48ab6f5398d2bf17f1f4c4fc0e0440c4aa3734a05ae523561e02e8a99957a": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "8ffc27373c8e9c5e32344b16d1b7f50a44323da6df4855deb6eadf8eb744eea8"
+     "public": "98dfc1375ce8818259ba23aa24bb596d6a60026e555285baccc1d3524677bcfe"
     },
     "scheme": "ed25519"
    },
-   "3515ef592c09ddb3a09da0096802afc26852dc7a1978cb1c99fbe3a6f5c0c1a1": {
+   "b7ad916e4138911155b771d0ede66666e9647e7fb6c85a1904be97dee5653568": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "a27a0209711787a4227cbfed23735a75b5f7f5cb0cd6acbf7a239fa2c3535434"
+     "public": "4cec23f563ae4d97e22c823ed8c3c2effed9ca568fab68179f0a338526003813"
     },
     "scheme": "ed25519"
    },
-   "5fcbe7c4faa87ab25bea551c0c4b0ac6e47a07caf5e7633314a784c54ad2ea8a": {
+   "cd9930c92ac25c02a2f92ae3128b50459b53d7532ef9c0f364e78f388d5808a5": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "41bf1adabf1f564de734fa5fb584a65b943317978a4dcbe39bab03ee722ee73f"
+     "public": "6849e4a7ca3e121cce7368dc939419fd2de031f4f33fc86083ff1bed4db8403a"
     },
     "scheme": "ed25519"
    },
-   "eb456bc4372b9aef1aea4790911d748a741d27ad0bd0eabcfe41e7fe3c6e9a8f": {
+   "eddb87d254d513c1404d71e17620ecf5260e1836babdaa55197916c582f37a00": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "f5033e2659886185ceedec69e2cfee0f348ea63dfffafd5f8566d001b45c470d"
+     "public": "6479fe966d5b5fb11d3339c18b42235bbe2a49e54966d6d1bc6a79e7985aedf8"
     },
     "scheme": "ed25519"
    }
@@ -57,26 +57,26 @@
   "roles": {
    "root": {
     "keyids": [
-     "eb456bc4372b9aef1aea4790911d748a741d27ad0bd0eabcfe41e7fe3c6e9a8f",
-     "1784b06ef8e18f906f3fd62f2fd81aa088bb58317da624e10b5a3ecb72bd662f"
+     "b7ad916e4138911155b771d0ede66666e9647e7fb6c85a1904be97dee5653568",
+     "1bd53d9d6f08f6efba19477880b348906f5f29a67d78cbca8a44aedfad12d003"
     ],
     "threshold": 2
    },
    "snapshot": {
     "keyids": [
-     "5fcbe7c4faa87ab25bea551c0c4b0ac6e47a07caf5e7633314a784c54ad2ea8a"
+     "5ef48ab6f5398d2bf17f1f4c4fc0e0440c4aa3734a05ae523561e02e8a99957a"
     ],
     "threshold": 1
    },
    "targets": {
     "keyids": [
-     "3515ef592c09ddb3a09da0096802afc26852dc7a1978cb1c99fbe3a6f5c0c1a1"
+     "cd9930c92ac25c02a2f92ae3128b50459b53d7532ef9c0f364e78f388d5808a5"
     ],
     "threshold": 1
    },
    "timestamp": {
     "keyids": [
-     "0eb56770be481c3a117f0487e7b6762edd0eaac7860ba85530dba400edf7de03"
+     "eddb87d254d513c1404d71e17620ecf5260e1836babdaa55197916c582f37a00"
     ],
     "threshold": 1
    }

--- a/tests/data/repository/metadata/root.json
+++ b/tests/data/repository/metadata/root.json
@@ -1,55 +1,55 @@
 {
  "signatures": [
   {
-   "keyid": "104c43225506bf7637a0061775a0d23ca8693e6bb4b270bc9ee9664259eb77d8",
-   "sig": "629f1d19e28f6a217b728509222b565ca7168be8cc094fed2e9c547c35da39b127b9914b49628789abef754d0615147aada1377af2fc6355ff49a42f31253e0a"
+   "keyid": "b7ad916e4138911155b771d0ede66666e9647e7fb6c85a1904be97dee5653568",
+   "sig": "740d4c6945050abd3abba7023cb5128a4e344e83ae0f52f9c978b7b3582dd21213e72a66dec6cd4206093c634cb973cf3ec0940103e54e6a81c4424322cf2d01"
   },
   {
-   "keyid": "eb456bc4372b9aef1aea4790911d748a741d27ad0bd0eabcfe41e7fe3c6e9a8f",
-   "sig": "05cd311026a0e5cece1d6d54b6b7f957f4824a704b7a319619621448a9ccb65ad9b1068429cf813aace000887eacf7a20000bacbc52777c9b11e9641d6f78f0c"
+   "keyid": "1bd53d9d6f08f6efba19477880b348906f5f29a67d78cbca8a44aedfad12d003",
+   "sig": "58ed242676830567413936feec20c80cd79d03fc31bdad38ffd0ef69e40298dfd8fe15edb7a4fd504a01ee5a7cddd3bfbd169ccd9bd2c6067e452aeee3a18102"
   },
   {
-   "keyid": "1784b06ef8e18f906f3fd62f2fd81aa088bb58317da624e10b5a3ecb72bd662f",
-   "sig": "933b34c60eeca55793e875e45993397ec2447608c3d73777f6e20b452223ab949a4c1c2b0e9a9f2374bd7ac9cdc06f397407320b1039ff256e21ea52500a6106"
+   "keyid": "d4ec748f9476f9f7e1f0a247b917dde4abe8a024de9ba34c7458b41bec8be6b2",
+   "sig": "7ea041490934e6637998eb22ab367f1d260b3d0cdde144cc5a776dda7a65c27a6061d1b62986851ecbc49ad04c7a428987b323c1c961f65f8e0143c792deb706"
   }
  ],
  "signed": {
   "_type": "root",
   "consistent_snapshot": false,
-  "expires": "2051-06-24T09:37:39Z",
+  "expires": "2051-06-25T13:08:48Z",
   "keys": {
-   "0eb56770be481c3a117f0487e7b6762edd0eaac7860ba85530dba400edf7de03": {
+   "1bd53d9d6f08f6efba19477880b348906f5f29a67d78cbca8a44aedfad12d003": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "2ec5e87c77fe70d918d92a1d849f4ec12907a34cf208123bbbc6d1e4bd584885"
+     "public": "b64b98945cc9e4c0997a896e3856f3198309d369ed2c54d59a7193ac63a40854"
     },
     "scheme": "ed25519"
    },
-   "1784b06ef8e18f906f3fd62f2fd81aa088bb58317da624e10b5a3ecb72bd662f": {
+   "5ef48ab6f5398d2bf17f1f4c4fc0e0440c4aa3734a05ae523561e02e8a99957a": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "8ffc27373c8e9c5e32344b16d1b7f50a44323da6df4855deb6eadf8eb744eea8"
+     "public": "98dfc1375ce8818259ba23aa24bb596d6a60026e555285baccc1d3524677bcfe"
     },
     "scheme": "ed25519"
    },
-   "3515ef592c09ddb3a09da0096802afc26852dc7a1978cb1c99fbe3a6f5c0c1a1": {
+   "b7ad916e4138911155b771d0ede66666e9647e7fb6c85a1904be97dee5653568": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "a27a0209711787a4227cbfed23735a75b5f7f5cb0cd6acbf7a239fa2c3535434"
+     "public": "4cec23f563ae4d97e22c823ed8c3c2effed9ca568fab68179f0a338526003813"
     },
     "scheme": "ed25519"
    },
-   "5fcbe7c4faa87ab25bea551c0c4b0ac6e47a07caf5e7633314a784c54ad2ea8a": {
+   "cd9930c92ac25c02a2f92ae3128b50459b53d7532ef9c0f364e78f388d5808a5": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "41bf1adabf1f564de734fa5fb584a65b943317978a4dcbe39bab03ee722ee73f"
+     "public": "6849e4a7ca3e121cce7368dc939419fd2de031f4f33fc86083ff1bed4db8403a"
     },
     "scheme": "ed25519"
    },
-   "eb456bc4372b9aef1aea4790911d748a741d27ad0bd0eabcfe41e7fe3c6e9a8f": {
+   "eddb87d254d513c1404d71e17620ecf5260e1836babdaa55197916c582f37a00": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "f5033e2659886185ceedec69e2cfee0f348ea63dfffafd5f8566d001b45c470d"
+     "public": "6479fe966d5b5fb11d3339c18b42235bbe2a49e54966d6d1bc6a79e7985aedf8"
     },
     "scheme": "ed25519"
    }
@@ -57,26 +57,26 @@
   "roles": {
    "root": {
     "keyids": [
-     "eb456bc4372b9aef1aea4790911d748a741d27ad0bd0eabcfe41e7fe3c6e9a8f",
-     "1784b06ef8e18f906f3fd62f2fd81aa088bb58317da624e10b5a3ecb72bd662f"
+     "b7ad916e4138911155b771d0ede66666e9647e7fb6c85a1904be97dee5653568",
+     "1bd53d9d6f08f6efba19477880b348906f5f29a67d78cbca8a44aedfad12d003"
     ],
     "threshold": 2
    },
    "snapshot": {
     "keyids": [
-     "5fcbe7c4faa87ab25bea551c0c4b0ac6e47a07caf5e7633314a784c54ad2ea8a"
+     "5ef48ab6f5398d2bf17f1f4c4fc0e0440c4aa3734a05ae523561e02e8a99957a"
     ],
     "threshold": 1
    },
    "targets": {
     "keyids": [
-     "3515ef592c09ddb3a09da0096802afc26852dc7a1978cb1c99fbe3a6f5c0c1a1"
+     "cd9930c92ac25c02a2f92ae3128b50459b53d7532ef9c0f364e78f388d5808a5"
     ],
     "threshold": 1
    },
    "timestamp": {
     "keyids": [
-     "0eb56770be481c3a117f0487e7b6762edd0eaac7860ba85530dba400edf7de03"
+     "eddb87d254d513c1404d71e17620ecf5260e1836babdaa55197916c582f37a00"
     ],
     "threshold": 1
    }

--- a/tests/data/repository/metadata/snapshot.json
+++ b/tests/data/repository/metadata/snapshot.json
@@ -1,13 +1,13 @@
 {
  "signatures": [
   {
-   "keyid": "5fcbe7c4faa87ab25bea551c0c4b0ac6e47a07caf5e7633314a784c54ad2ea8a",
-   "sig": "814c447447a834e1072e5a76c5b91d3cd2234c52ee63789c90f05f8ac7679a5e6e10149c1cacfd2fe92bb1f3db186374c8acc28abc9d96d1bd2afa46540a4200"
+   "keyid": "5ef48ab6f5398d2bf17f1f4c4fc0e0440c4aa3734a05ae523561e02e8a99957a",
+   "sig": "29c6c8a45e7c0940e51cac1b9052304bb0baec1e1df35885522846ae5abd039c1846c453cd599ccc36e11c4f0a52de6b772d71627886e22dc77822b4404af602"
   }
  ],
  "signed": {
   "_type": "snapshot",
-  "expires": "2051-06-24T09:37:39Z",
+  "expires": "2051-06-25T13:08:48Z",
   "meta": {
    "targets.json": {
     "version": 6

--- a/tests/data/repository/metadata/targets.json
+++ b/tests/data/repository/metadata/targets.json
@@ -1,13 +1,13 @@
 {
  "signatures": [
   {
-   "keyid": "3515ef592c09ddb3a09da0096802afc26852dc7a1978cb1c99fbe3a6f5c0c1a1",
-   "sig": "dd175aeed38f8a1a844507fa465e36be5577920becd6fd44d424de3b8caac4e4d9ac9b3afd2813e12b8412ff963495d16bdff0e4035b98d7026518018aadd005"
+   "keyid": "cd9930c92ac25c02a2f92ae3128b50459b53d7532ef9c0f364e78f388d5808a5",
+   "sig": "dbcc91a73275a2478489e491b3054328659ce5e7cdeeb7623fe41e745cbe585a0dc874e05d80a291c5658138549051a24d81f3fb61093b6133b5d3e8927e9e01"
   }
  ],
  "signed": {
   "_type": "targets",
-  "expires": "2051-06-24T09:37:39Z",
+  "expires": "2051-06-25T13:08:48Z",
   "spec_version": "1.0.31",
   "targets": {
    "example_app-1.0.tar.gz": {
@@ -17,45 +17,57 @@
     "length": 101613
    },
    "example_app-2.0.patch": {
-    "custom": {
-     "whatever": "important"
-    },
     "hashes": {
      "sha256": "f7ee90e00fa69d5832eeee193f9b6bb2d32ff028c413f47fbaf853b3d2add27f"
     },
     "length": 18709
    },
    "example_app-2.0.tar.gz": {
+    "custom": {
+     "changes": [
+      "this has changed",
+      "that has changed",
+      "..."
+     ]
+    },
     "hashes": {
      "sha256": "d85f423a56427e522ac4d093a6ce94abcc2cc32f99b80a39b87832d8e4ba9ad8"
     },
     "length": 101744
    },
    "example_app-3.0rc0.patch": {
-    "custom": {
-     "whatever": "important"
-    },
     "hashes": {
      "sha256": "dcf2ce8ca9fc0ccc0e541fb0fca97a7772374177197a41fa4cf17653ef850956"
     },
     "length": 6458
    },
    "example_app-3.0rc0.tar.gz": {
+    "custom": {
+     "changes": [
+      "this has changed",
+      "that has changed",
+      "..."
+     ]
+    },
     "hashes": {
      "sha256": "d7fa6ddd397282e8fa81924a31f340ebbcb8c082604c0549a38f5882cd3716c6"
     },
     "length": 101841
    },
    "example_app-4.0a0.patch": {
-    "custom": {
-     "whatever": "important"
-    },
     "hashes": {
      "sha256": "0fc6918d6d0757e234fe550e26bca659503166da3d3f493ec6bdbb5281b356ce"
     },
     "length": 102567
    },
    "example_app-4.0a0.tar.gz": {
+    "custom": {
+     "changes": [
+      "this has changed",
+      "that has changed",
+      "..."
+     ]
+    },
     "hashes": {
      "sha256": "05304765a0cb4e40cbd7ca2587aeb5f0db36cd9b617921e0d141bb91d3304e2c"
     },

--- a/tests/data/repository/metadata/timestamp.json
+++ b/tests/data/repository/metadata/timestamp.json
@@ -1,13 +1,13 @@
 {
  "signatures": [
   {
-   "keyid": "0eb56770be481c3a117f0487e7b6762edd0eaac7860ba85530dba400edf7de03",
-   "sig": "c1a5016ddce626ded84fe28b2c4830e50865c43bb70d3986a81f61f524d31aaaa80d3abe9282f434ec95e4a82c513942ce55f8e38a8c39cdf170ee7b5aec8a06"
+   "keyid": "eddb87d254d513c1404d71e17620ecf5260e1836babdaa55197916c582f37a00",
+   "sig": "bc22b24fadb6fabbc915cd7c5dd704cd338bad94d268f53e5c5e743fbbb707dfa8e339b5d5a6fefa4360431d610e383c6744d2e7306121d4cd4bd2388ecfef02"
   }
  ],
  "signed": {
   "_type": "timestamp",
-  "expires": "2051-06-24T09:37:39Z",
+  "expires": "2051-06-25T13:08:48Z",
   "meta": {
    "snapshot.json": {
     "version": 7

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -98,11 +98,11 @@ class ClientTests(TempDirTestCase):
     def test_trusted_target_metas(self):
         client = self.get_refreshed_client()
         self.assertTrue(client.trusted_target_metas)
-        # in the example data, only the patches have custom metadata, as defined in
+        # in the test data, only the archives have custom metadata, as defined in
         # the repo_workflow_example.py script
         for meta in client.trusted_target_metas:
             with self.subTest(msg=meta):
-                if meta.is_patch:
+                if meta.is_archive and str(meta.version) != '1.0':
                     self.assertTrue(meta.custom)
                     self.assertIsInstance(meta.custom, dict)
                 else:

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -752,8 +752,7 @@ class RepositoryTests(TempDirTestCase):
         repo.add_bundle(
             new_version=version,
             new_bundle_dir=bundle_dir,
-            custom_metadata_for_archive=dict(whatever='something'),
-            custom_metadata_for_patch=None,
+            custom_metadata=dict(whatever='something'),
         )
         self.assertTrue((repo.metadata_dir / 'targets.json').exists())
         target_name = f'{app_name}-{version}.tar.gz'


### PR DESCRIPTION
Custom metadata as [described in the TUF spec][1] can be specified when adding a new bundle to a repository.

The high-level interface has been simplified slightly w.r.t. #100: users can now only add custom metadata to the *archive*, not to the patch (if any).

This makes sense, because the *archive* is the only thing a typical user should be interested in (patches are considered an internal implementation detail). If *really* necessary, the low-level `Roles.add_or_update_target()` can still be used to add custom metadata to *patches*.

### Examples

On the repo side:

```python
...
repo.add_bundle(
    new_version='2.3.4',
    new_bundle_dir='dist/myapp',
    custom_metadata=dict(foo='bar'),  # optional
)
...
```
The custom metadata ends up in the `targets.json` file as follows:

```json
{
  "signatures": [
    "..."
  ],
  "signed": {
    "...": "...",
    "targets": {
      "...": {},
      "myapp-2.3.4.tar.gz": {
        "custom": {
          "foo": "bar"
        },
        "hashes": {
          "sha256": "..."
        },
        "length": 12345
      },
      "...": {}
    }
  }
}
```

On the client side, this metadata is made available via the `TargetMeta` class.  Note that `Client.check_for_updates()` only ever returns a `TargetMeta` instance for the *archive*, regardless of whether a patch update or a full update will be performed. 

For example,  

```python
...
new_archive_meta = client.check_for_updates()
if new_archive_meta:
    ...
    if new_archive_meta.custom:
        ...
```

fixes #99

[1]: https://theupdateframework.github.io/specification/latest/#custom