### PR TITLE
Upgrade tuf dependency to 4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "packaging>=21.3",
     "securesystemslib[crypto,pynacl]>=0.26.0",
     "setuptools>=65.5.1",
-    "tuf==3.1.*",
+    "tuf==4.0.*",
     # constraints on sub-dependencies
     "certifi>=2022.12.7",
     "cryptography>=38.0.3",

--- a/src/tufup/client.py
+++ b/src/tufup/client.py
@@ -70,7 +70,7 @@ class Client(tuf.ngclient.Updater):
         if self._trusted_set.targets:
             _trusted_target_metas = [
                 TargetMeta(target_path=key, custom=target.custom)
-                for key, target in self._trusted_set.targets.signed.targets.items()
+                for key, target in self._trusted_set.targets.targets.items()
             ]
             logger.debug(f'{len(_trusted_target_metas)} TargetMeta objects created')
         else:


### PR DESCRIPTION
The public API changes in [python-tuf v4.0.0][1] do not seem to affect us, but  theupdateframework/python-tuf@cb9aa4a does affect our client, due to my ill-fated choice to use the *private* `ngclient.Updater._trusted_set`.

fixes #133

related to secure-systems-lab/securesystemslib#767

[1]: https://github.com/theupdateframework/python-tuf/releases/tag/v4.0.0