### PR TITLE
Expose symlinks option for updates on macOS

### DIFF
--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -953,6 +953,7 @@ class Repository(object):
 
     def _load_keys_and_roles(self, create_keys: bool = False):
         # todo: make public, rename load_keys_and_metadata
+        # todo: check import success (now says "metadata imported" even if files not found)
         if self.keys is None:
             logger.info('Importing public keys...')
             self.keys = Keys(

--- a/src/tufup/utils/platform_specific.py
+++ b/src/tufup/utils/platform_specific.py
@@ -239,8 +239,14 @@ def _install_update_mac(
     dst_dir: Union[pathlib.Path, str],
     purge_dst_dir: bool,
     exclude_from_purge: List[Union[pathlib.Path, str]],
+    symlinks: bool = False,
     **kwargs,
 ):
+    """
+    The symlinks arg is passed on to shutil.copytree()
+
+    [1]: https://docs.python.org/3/library/shutil.html#shutil.copytree
+    """
     # todo: implement as_admin and debug kwargs for mac
     logger.debug(f'Kwargs not used: {kwargs}')
     if purge_dst_dir:
@@ -256,7 +262,7 @@ def _install_update_mac(
             if path not in exclude_from_purge:
                 remove_path(path=path)
     logger.debug(f'Moving content of {src_dir} to {dst_dir}.')
-    shutil.copytree(src_dir, dst_dir, dirs_exist_ok=True)
+    shutil.copytree(src_dir, dst_dir, dirs_exist_ok=True, symlinks=symlinks)
     # Note: the src_dir is typically a temporary directory, but we'll clear
     # it anyway just to be consistent with the windows implementation
     for path in pathlib.Path(src_dir).iterdir():

--- a/tests/test_utils_platform_specific.py
+++ b/tests/test_utils_platform_specific.py
@@ -97,8 +97,6 @@ class UtilsTests(TempDirTestCase):
     @unittest.skipIf(condition=not ON_MAC, reason='macOS only')
     def test_install_update_macos_symlinks(self):
         with patch.object(ps, '_install_update_mac') as mock_install_update_mac:
-            ps.install_update(src_dir='', dst_dir='')
-            mock_install_update_mac.assert_called_with(symlinks=False)
             ps.install_update(src_dir='', dst_dir='', symlinks=True)
             mock_install_update_mac.assert_called_with(symlinks=True)
 

--- a/tests/test_utils_platform_specific.py
+++ b/tests/test_utils_platform_specific.py
@@ -7,9 +7,12 @@ import tempfile
 import textwrap
 from time import sleep
 import unittest
+from unittest.mock import patch
 
 from tests import BASE_DIR, TempDirTestCase
+import tufup.utils.platform_specific as ps
 from tufup.utils.platform_specific import (
+    ON_MAC,
     ON_WINDOWS,
     PLATFORM_SUPPORTED,
     run_bat_as_admin,
@@ -90,6 +93,14 @@ class UtilsTests(TempDirTestCase):
         print(f'current user: {current_user}')
         self.assertTrue(len(output))
         self.assertNotIn(current_user, output)
+
+    @unittest.skipIf(condition=not ON_MAC, reason='macOS only')
+    def test_install_update_macos_symlinks(self):
+        with patch.object(ps, '_install_update_mac') as mock_install_update_mac:
+            ps.install_update(src_dir='', dst_dir='')
+            mock_install_update_mac.assert_called_with(symlinks=False)
+            ps.install_update(src_dir='', dst_dir='', symlinks=True)
+            mock_install_update_mac.assert_called_with(symlinks=True)
 
     @unittest.skipIf(
         condition=not PLATFORM_SUPPORTED, reason=_reason_platform_not_supported

--- a/tests/test_utils_platform_specific.py
+++ b/tests/test_utils_platform_specific.py
@@ -97,8 +97,10 @@ class UtilsTests(TempDirTestCase):
     @unittest.skipIf(condition=not ON_MAC, reason='macOS only')
     def test_install_update_macos_symlinks(self):
         with patch.object(ps, '_install_update_mac') as mock_install_update_mac:
+            ps.install_update(src_dir='', dst_dir='')
+            self.assertNotIn('symlinks', mock_install_update_mac.call_args.kwargs)
             ps.install_update(src_dir='', dst_dir='', symlinks=True)
-            mock_install_update_mac.assert_called_with(symlinks=True)
+            self.assertTrue(mock_install_update_mac.call_args.kwargs['symlinks'])
 
     @unittest.skipIf(
         condition=not PLATFORM_SUPPORTED, reason=_reason_platform_not_supported


### PR DESCRIPTION
On macOS, it may be necessary, as in #145, to enable `symlinks` when files are moved into the `app_install_dir` using `shutil.copytree()`.

From the `shutil.copytree` [docs][1]:

>If symlinks is true, symbolic links in the source tree are represented as symbolic links in the new tree and the metadata of the original links will be copied as far as the platform allows; if false or omitted, the contents and metadata of the linked files are copied to the new tree.

This PR exposes the `symlinks` argument so user can enable this behavior as follows:

```python
client.download_and_apply_updates(..., symlinks=True)
```

If not specified, the *default* setting from `shutil.copytree` is used, i.e. `symlinks=False`.

fixes #145

[1]: https://docs.python.org/3/library/shutil.html#shutil.copytree