### PR TITLE
drop support for python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         # see currently supported releases: https://devguide.python.org/versions/
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     # direct dependencies
     "bsdiff4==1.2.*",


### PR DESCRIPTION
- dropped support for python 3.8
- added python 3.13 to test matrix

dropping support could be considered a backward incompatible change, but we require python>=3.9, so users running 3.8 simply cannot  install the new version of tufup

fixes #106