### PR TITLE
Customizable binary diff for patch creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,18 @@
 name: lint and unittest
 
 on:
-  - push
-  - pull_request
-  # enable manual trigger
-  - workflow_dispatch
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
   # make reusable
-  - workflow_call
-  
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     # based on [1]
@@ -35,19 +40,19 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Lint with ruff
-      run: |
-        pip install ruff
-        ruff check --output-format=github .
-    - name: Test with unittest
-      run: |
-        python -m unittest
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint with ruff
+        run: |
+          pip install ruff
+          ruff check --output-format=github .
+      - name: Test with unittest
+        run: |
+          python -m unittest

--- a/examples/client/example_app.py
+++ b/examples/client/example_app.py
@@ -2,7 +2,10 @@ import logging
 import pathlib
 import shutil
 
+import bsdiff4
+
 from tufup.client import Client
+from tufup.common import BinaryDiff
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +42,18 @@ METADATA_BASE_URL = 'http://localhost:8000/metadata/'
 TARGET_BASE_URL = 'http://localhost:8000/targets/'
 
 
+# By default, tufup uses bsdiff4 to create patches, but we can override that.
+# Here's a dummy example (just extending bsdiff4).
+# You do not need to do this if you're happy with the default bsdiff4.
+class CustomBinaryDiff(BinaryDiff):
+    diff = bsdiff4.diff
+
+    @staticmethod
+    def patch(*, src_bytes: bytes, patch_bytes: bytes) -> bytes:
+        logger.info('this is a custom patch, but we still use bsdiff4 for convenience')
+        return bsdiff4.patch(src_bytes=src_bytes, patch_bytes=patch_bytes)
+
+
 def main():
     # The app must ensure dirs exist
     for dir_path in [APP_INSTALL_DIR, METADATA_DIR, TARGET_DIR]:
@@ -65,6 +80,7 @@ def main():
         target_dir=TARGET_DIR,
         target_base_url=TARGET_BASE_URL,
         refresh_required=False,
+        binary_diff=CustomBinaryDiff,
     )
 
     # Perform update

--- a/examples/repo/repo_workflow_example.py
+++ b/examples/repo/repo_workflow_example.py
@@ -6,6 +6,9 @@ import secrets  # from python 3.9+ we can use random.randbytes
 import shutil
 import tempfile
 
+import bsdiff4
+
+from tufup.common import BinaryDiff
 from tufup.repo import (
     DEFAULT_KEY_MAP,
     DEFAULT_KEYS_DIR_NAME,
@@ -93,6 +96,18 @@ ENCRYPTED_KEYS = ['root', 'root_two', 'targets']
 # Custom metadata (for example, a list of changes)
 DUMMY_METADATA = dict(changes=['this has changed', 'that has changed', '...'])
 
+
+# By default, tufup uses bsdiff4 to create patches, but we can override that.
+# Here's a dummy example (just extending bsdiff4).
+class CustomBinaryDiff(BinaryDiff):
+    patch = bsdiff4.patch
+
+    @staticmethod
+    def diff(*, src_bytes: bytes, dst_bytes: bytes) -> bytes:
+        logger.info('this is a custom diff, but we still use bsdiff4 for convenience')
+        return bsdiff4.diff(src_bytes=src_bytes, dst_bytes=dst_bytes)
+
+
 # Create repository instance
 repo = Repository(
     app_name=APP_NAME,
@@ -102,6 +117,7 @@ repo = Repository(
     expiration_days=EXPIRATION_DAYS,
     encrypted_keys=ENCRYPTED_KEYS,
     thresholds=THRESHOLDS,
+    binary_diff=CustomBinaryDiff,
 )
 
 # Save configuration (JSON file)

--- a/examples/repo/repo_workflow_example.py
+++ b/examples/repo/repo_workflow_example.py
@@ -99,6 +99,7 @@ DUMMY_METADATA = dict(changes=['this has changed', 'that has changed', '...'])
 
 # By default, tufup uses bsdiff4 to create patches, but we can override that.
 # Here's a dummy example (just extending bsdiff4).
+# You do not need to do this if you're happy with the default bsdiff4.
 class CustomBinaryDiff(BinaryDiff):
     patch = bsdiff4.patch
 

--- a/src/tufup/__init__.py
+++ b/src/tufup/__init__.py
@@ -5,7 +5,7 @@ from tufup.repo import cli
 
 # https://packaging.python.org/en/latest/guides/single-sourcing-package-version/
 # https://semver.org/
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 
 logger = logging.getLogger(__name__)
 

--- a/src/tufup/client.py
+++ b/src/tufup/client.py
@@ -12,7 +12,7 @@ from requests.auth import AuthBase
 from tuf.api.exceptions import DownloadError, UnsignedMetadataError
 import tuf.ngclient
 
-from tufup.common import KEY_REQUIRED, Patcher, TargetMeta
+from tufup.common import BinaryDiff, KEY_REQUIRED, Patcher, TargetMeta
 from tufup.utils.platform_specific import install_update
 
 logger = logging.getLogger(__name__)
@@ -36,6 +36,7 @@ class Client(tuf.ngclient.Updater):
         extract_dir: Optional[pathlib.Path] = None,
         refresh_required: bool = False,
         session_auth: Optional[Dict[str, Union[Tuple[str, str], AuthBase]]] = None,
+        binary_diff: Optional[type[BinaryDiff]] = None,
         **kwargs,
     ):
         """
@@ -61,6 +62,7 @@ class Client(tuf.ngclient.Updater):
         self.new_archive_info: Optional[tuf.ngclient.TargetFile] = None
         self.new_targets: Optional[dict] = None
         self.downloaded_target_files = {}
+        self.binary_diff = binary_diff
 
     @property
     def trusted_target_metas(self) -> list:
@@ -301,6 +303,7 @@ class Client(tuf.ngclient.Updater):
                     src_path=self.current_archive_local_path,
                     dst_path=self.new_archive_local_path,
                     patch_targets=self.downloaded_target_files,
+                    binary_diff=self.binary_diff,
                 )
         except Exception as e:
             # rename all failed targets in order to skip them (patches) or retry

--- a/src/tufup/common.py
+++ b/src/tufup/common.py
@@ -257,7 +257,7 @@ class Patcher(object):
         src_path: pathlib.Path,
         dst_path: pathlib.Path,
         patch_path: pathlib.Path,
-        binary_diff: Optional[BinaryDiff] = None,
+        binary_diff: Optional[type[BinaryDiff]] = None,
     ) -> dict:
         """
         Creates a patch file from the binary difference between source and destination
@@ -286,7 +286,7 @@ class Patcher(object):
         src_path: pathlib.Path,
         dst_path: pathlib.Path,
         patch_targets: Dict[TargetMeta, pathlib.Path],
-        binary_diff: Optional[BinaryDiff] = None,
+        binary_diff: Optional[type[BinaryDiff]] = None,
     ) -> None:
         """
         Applies one or more binary patch files to a source file in order to

--- a/src/tufup/common.py
+++ b/src/tufup/common.py
@@ -257,7 +257,7 @@ class Patcher(object):
         src_path: pathlib.Path,
         dst_path: pathlib.Path,
         patch_path: pathlib.Path,
-        binary_diff: BinaryDiff = DefaultBinaryDiff,
+        binary_diff: Optional[BinaryDiff] = None,
     ) -> dict:
         """
         Creates a patch file from the binary difference between source and destination
@@ -269,6 +269,7 @@ class Patcher(object):
 
         Returns a dict with size and hash of the *uncompressed* destination archive.
         """
+        binary_diff = binary_diff or DefaultBinaryDiff
         with gzip.open(src_path, mode='rb') as src_file:
             with gzip.open(dst_path, mode='rb') as dst_file:
                 dst_tar_content = dst_file.read()
@@ -285,7 +286,7 @@ class Patcher(object):
         src_path: pathlib.Path,
         dst_path: pathlib.Path,
         patch_targets: Dict[TargetMeta, pathlib.Path],
-        binary_diff: BinaryDiff = DefaultBinaryDiff,
+        binary_diff: Optional[BinaryDiff] = None,
     ) -> None:
         """
         Applies one or more binary patch files to a source file in order to
@@ -304,6 +305,7 @@ class Patcher(object):
         The binary patching method can be customized by implementing a `BinaryDiff`
         subclass and passing this in via the `binary_diff` argument.
         """
+        binary_diff = binary_diff or DefaultBinaryDiff
         if not patch_targets:
             raise ValueError('no patch targets')
         # decompress .tar data from source .tar.gz file

--- a/src/tufup/common.py
+++ b/src/tufup/common.py
@@ -211,13 +211,8 @@ class BinaryDiff(ABC):
 class DefaultBinaryDiff(BinaryDiff):
     """The default implementation of binary differencing and patching functions"""
 
-    @staticmethod
-    def diff(src_bytes: bytes, dst_bytes: bytes) -> bytes:
-        return bsdiff4.diff(src_bytes=src_bytes, dst_bytes=dst_bytes)
-
-    @staticmethod
-    def patch(src_bytes: bytes, patch_bytes: bytes) -> bytes:
-        return bsdiff4.patch(src_bytes=src_bytes, patch_bytes=patch_bytes)
+    diff = bsdiff4.diff
+    patch = bsdiff4.patch
 
 
 class Patcher(object):

--- a/src/tufup/common.py
+++ b/src/tufup/common.py
@@ -198,11 +198,13 @@ class BinaryDiff(ABC):
     @staticmethod
     @abstractmethod
     def diff(*, src_bytes: bytes, dst_bytes: bytes) -> bytes:
+        """Create patch as the binary difference between source and destination data"""
         pass
 
     @staticmethod
     @abstractmethod
     def patch(*, src_bytes: bytes, patch_bytes: bytes) -> bytes:
+        """Apply binary patch to source data to recover destination data"""
         pass
 
 
@@ -267,6 +269,9 @@ class Patcher(object):
         .tar archives. The source and destination files are expected to be
         gzip-compressed tar archives (.tar.gz).
 
+        The binary differencing method can be customized by implementing a `BinaryDiff`
+        subclass and passing this in via the `binary_diff` argument.
+
         Returns a dict with size and hash of the *uncompressed* destination archive.
         """
         with gzip.open(src_path, mode='rb') as src_file:
@@ -300,6 +305,9 @@ class Patcher(object):
         and hash (from custom tuf metadata), similar to python-tuf's download
         verification. If the patched archive fails this check, the destination file
         is not written.
+
+        The binary patching method can be customized by implementing a `BinaryDiff`
+        subclass and passing this in via the `binary_diff` argument.
         """
         if not patch_targets:
             raise ValueError('no patch targets')

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -121,7 +121,9 @@ def make_gztar_archive(
     return TargetMeta(target_path=archive_path)
 
 
-def get_binary_diff_class(fully_qualified_name: Optional[str]) -> Optional[type[BinaryDiff]]:
+def get_binary_diff_class(
+    fully_qualified_name: Optional[str]
+) -> Optional[type[BinaryDiff]]:
     """get a BinaryDiff instance from a fully qualified class name"""
     if fully_qualified_name is not None:
         try:

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -39,13 +39,14 @@ from tuf.api.metadata import (
 from tuf.api.serialization.json import JSONSerializer
 
 from tufup.common import (
+    BinaryDiff,
     CustomMetadataDict,
     KEY_REQUIRED,
     Patcher,
     SUFFIX_PATCH,
     TargetMeta,
 )
-from tufup.utils.platform_specific import _patched_resolve
+from tufup.utils.platform_specific import _patched_resolve  # noqa
 
 logger = logging.getLogger(__name__)
 
@@ -533,6 +534,7 @@ class Repository(object):
         encrypted_keys: Optional[List[str]] = None,
         expiration_days: Optional[RolesDict] = None,
         thresholds: Optional[RolesDict] = None,
+        binary_diff: Optional[BinaryDiff] = None,
     ):
         if repo_dir is None:
             repo_dir = DEFAULT_REPO_DIR_NAME
@@ -555,6 +557,7 @@ class Repository(object):
         self.encrypted_keys = encrypted_keys
         self.expiration_days = expiration_days
         self.thresholds = thresholds
+        self.binary_diff = binary_diff
         # keys and roles
         self.keys: Optional[Keys] = None
         self.roles: Optional[Roles] = None
@@ -801,7 +804,10 @@ class Repository(object):
                 patch_path = dst_path.with_suffix('').with_suffix(SUFFIX_PATCH)
                 # create patch
                 dst_size_and_hash = Patcher.diff_and_hash(
-                    src_path=src_path, dst_path=dst_path, patch_path=patch_path
+                    src_path=src_path,
+                    dst_path=dst_path,
+                    patch_path=patch_path,
+                    binary_diff=self.binary_diff,
                 )
                 # register patch (size and hash are used by the client to verify the
                 # integrity of the patched archive)

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -604,13 +604,17 @@ class Repository(object):
         temp_config_dict = self.config_dict  # note self.config_dict is a property
         for key in ['repo_dir', 'keys_dir']:
             try:
-                temp_config_dict[key] = temp_config_dict[key].relative_to(
-                    # resolve() is necessary on windows, to handle "short"
-                    # path components (a.k.a. "8.3 filename" or "8.3 alias"),
-                    # which are truncated with a tilde,
-                    # e.g. c:\Users\RUNNER~1\...
-                    pathlib.Path.cwd().resolve()
-                ).as_posix()
+                temp_config_dict[key] = (
+                    temp_config_dict[key]
+                    .relative_to(
+                        # resolve() is necessary on windows, to handle "short"
+                        # path components (a.k.a. "8.3 filename" or "8.3 alias"),
+                        # which are truncated with a tilde,
+                        # e.g. c:\Users\RUNNER~1\...
+                        pathlib.Path.cwd().resolve()
+                    )
+                    .as_posix()
+                )
             except ValueError:
                 logger.warning(
                     f'Saving *absolute* path to config, because the path'

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -625,8 +625,9 @@ class Repository(object):
         # save binary_diff module and class name
         binary_diff = temp_config_dict['binary_diff']
         if binary_diff:
-            temp_config_dict['binary_diff'] = dict(
-                module=binary_diff.__module__, classname=binary_diff.__name__
+            # store fully qualified class name
+            temp_config_dict['binary_diff'] = '.'.join(
+                [binary_diff.__module__, binary_diff.__name__]
             )
         # write file
         config_file_path.write_text(
@@ -658,12 +659,13 @@ class Repository(object):
         """Create Repository instance from configuration file."""
         kwargs = cls.load_config()
         # import custom binary_diff class based on config info
-        binary_diff = kwargs.pop('binary_diff', dict())
+        binary_diff = kwargs.pop('binary_diff', '')
         if binary_diff:
             try:
+                # split fully qualified name into module and class name
+                module, classname = binary_diff.rsplit('.', 1)
                 kwargs['binary_diff'] = getattr(
-                    importlib.import_module(name=binary_diff['module']),
-                    binary_diff['classname'],
+                    importlib.import_module(name=module), classname
                 )
             except Exception as e:
                 kwargs['binary_diff'] = None

--- a/src/tufup/repo/__init__.py
+++ b/src/tufup/repo/__init__.py
@@ -535,7 +535,7 @@ class Repository(object):
         encrypted_keys: Optional[List[str]] = None,
         expiration_days: Optional[RolesDict] = None,
         thresholds: Optional[RolesDict] = None,
-        binary_diff: Optional[BinaryDiff] = None,
+        binary_diff: Optional[type[BinaryDiff]] = None,
     ):
         if repo_dir is None:
             repo_dir = DEFAULT_REPO_DIR_NAME

--- a/tests/test_common_.py
+++ b/tests/test_common_.py
@@ -229,6 +229,7 @@ class PatcherTests(TempDirTestCase):
             )
 
     def test_diff_and_hash(self):
+        # todo: explicitly test the binary_diff argument?
         # prepare
         src = 'v-1'
         dst = 'v-2'
@@ -244,6 +245,7 @@ class PatcherTests(TempDirTestCase):
         self.assertEqual(self.tar_fingerprints[dst], dst_fingerprint)
 
     def test_patch_and_verify(self):
+        # todo: explicitly test the binary_diff argument?
         # prepare
         src = 'v-1'
         dst = 'v-3'  # note we're skipping v-2

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -26,7 +26,7 @@ from tuf.api.metadata import (
 )
 
 from tests import TempDirTestCase, TEST_REPO_DIR
-from tufup.common import KEY_REQUIRED, TargetMeta
+from tufup.common import DefaultBinaryDiff, KEY_REQUIRED, TargetMeta
 import tufup.repo  # for patching
 from tufup.repo import (
     Base,
@@ -516,7 +516,7 @@ class RepositoryTests(TempDirTestCase):
             'keys_dir': None,
             'repo_dir': None,
             'thresholds': None,
-            'binary_diff': None
+            'binary_diff': None,
         }
         self.assertEqual(set(expected_config_dict), set(repo.config_dict))
 
@@ -563,8 +563,21 @@ class RepositoryTests(TempDirTestCase):
                 self.assertEqual(kwargs[key].replace('\\', '/'), config[key])
 
     def test_save_config_binary_diff(self):
-        # todo: test binary_diff
-        raise NotImplemented
+        cases = [
+            (None, None),
+            (DefaultBinaryDiff, dict(classname='DefaultBinaryDiff', module='tufup.common')),
+        ]
+        for binary_diff, expected in cases:
+            with self.subTest(msg=binary_diff):
+                # prepare
+                repo = Repository(app_name='test', binary_diff=binary_diff)
+                # test
+                repo.save_config()
+                self.assertTrue(repo.get_config_file_path().exists())
+                config_text = repo.get_config_file_path().read_text()
+                print(config_text)
+                config = json.loads(repo.get_config_file_path().read_text())
+                self.assertEqual(expected, config.get('binary_diff'))
 
     def test_load_config(self):
         # file does not exist
@@ -630,7 +643,7 @@ class RepositoryTests(TempDirTestCase):
 
     def test_from_config_binary_diff(self):
         # todo: test binary_diff
-        raise NotImplemented
+        raise NotImplementedError
 
     def test_initialize(self):
         # prepare

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -562,6 +562,10 @@ class RepositoryTests(TempDirTestCase):
             with self.subTest(msg=key):
                 self.assertEqual(kwargs[key].replace('\\', '/'), config[key])
 
+    def test_save_config_binary_diff(self):
+        # todo: test binary_diff
+        raise NotImplemented
+
     def test_load_config(self):
         # file does not exist
         self.assertEqual(dict(), Repository.load_config())
@@ -623,6 +627,10 @@ class RepositoryTests(TempDirTestCase):
                     {key: getattr(repo, key) for key in config_data.keys()},
                 )
                 self.assertTrue(mmock_load.called)
+
+    def test_from_config_binary_diff(self):
+        # todo: test binary_diff
+        raise NotImplemented
 
     def test_initialize(self):
         # prepare

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -516,6 +516,7 @@ class RepositoryTests(TempDirTestCase):
             'keys_dir': None,
             'repo_dir': None,
             'thresholds': None,
+            'binary_diff': None
         }
         self.assertEqual(set(expected_config_dict), set(repo.config_dict))
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -30,6 +30,7 @@ from tufup.common import DefaultBinaryDiff, KEY_REQUIRED, TargetMeta
 import tufup.repo  # for patching
 from tufup.repo import (
     Base,
+    get_binary_diff_class,
     in_,
     Keys,
     make_gztar_archive,
@@ -105,6 +106,14 @@ class ModuleTests(TempDirTestCase):
             self.assertTrue(archive.path.exists())
             self.assertTrue(app_name in str(archive.path))
             self.assertTrue(version in str(archive.path))
+
+    def test_get_binary_diff_class(self):
+        cases = [(None, None), ('tufup.common.DefaultBinaryDiff', DefaultBinaryDiff)]
+        for name, expected in cases:
+            with self.subTest(msg=name):
+                self.assertIs(
+                    get_binary_diff_class(fully_qualified_name=name), expected
+                )
 
 
 class BaseTests(TempDirTestCase):

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -565,7 +565,10 @@ class RepositoryTests(TempDirTestCase):
     def test_save_config_binary_diff(self):
         cases = [
             (None, None),
-            (DefaultBinaryDiff, dict(classname='DefaultBinaryDiff', module='tufup.common')),
+            (
+                DefaultBinaryDiff,
+                dict(classname='DefaultBinaryDiff', module='tufup.common'),
+            ),
         ]
         for binary_diff, expected in cases:
             with self.subTest(msg=binary_diff):
@@ -642,8 +645,34 @@ class RepositoryTests(TempDirTestCase):
                 self.assertTrue(mmock_load.called)
 
     def test_from_config_binary_diff(self):
-        # todo: test binary_diff
-        raise NotImplementedError
+        cases = [
+            (None, None),
+            (
+                dict(classname='DefaultBinaryDiff', module='tufup.common'),
+                DefaultBinaryDiff,
+            ),
+        ]
+        for binary_diff, expected in cases:
+            with self.subTest(msg=binary_diff):
+                # prepare
+                config_data = dict(
+                    app_name='test',
+                    app_version_attr='my_app.__version__',
+                    repo_dir='repo',
+                    keys_dir='keystore',
+                    key_map=dict(),
+                    encrypted_keys=[],
+                    expiration_days=dict(),
+                    thresholds=dict(),
+                    binary_diff=binary_diff,
+                )
+                Repository.get_config_file_path().write_text(
+                    json.dumps(config_data, default=str)
+                )
+                # test
+                with patch.object(Repository, '_load_keys_and_roles'):
+                    repo = Repository.from_config()
+                self.assertIs(repo.binary_diff, expected)
 
     def test_initialize(self):
         # prepare

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -565,10 +565,7 @@ class RepositoryTests(TempDirTestCase):
     def test_save_config_binary_diff(self):
         cases = [
             (None, None),
-            (
-                DefaultBinaryDiff,
-                dict(classname='DefaultBinaryDiff', module='tufup.common'),
-            ),
+            (DefaultBinaryDiff, 'tufup.common.DefaultBinaryDiff'),
         ]
         for binary_diff, expected in cases:
             with self.subTest(msg=binary_diff):
@@ -647,10 +644,7 @@ class RepositoryTests(TempDirTestCase):
     def test_from_config_binary_diff(self):
         cases = [
             (None, None),
-            (
-                dict(classname='DefaultBinaryDiff', module='tufup.common'),
-                DefaultBinaryDiff,
-            ),
+            ('tufup.common.DefaultBinaryDiff', DefaultBinaryDiff),
         ]
         for binary_diff, expected in cases:
             with self.subTest(msg=binary_diff):

--- a/tests/test_repo_cli.py
+++ b/tests/test_repo_cli.py
@@ -223,6 +223,7 @@ class CommandTests(TempDirTestCase):
             [
                 'my-app',  # app name
                 'my_app.__version__',  # app version
+                'my_module.MyBinaryDiff',  # binary_diff
                 'repo/dir',  # repo dir
                 'keys/dir',  # keys dir
                 yes,  # keep default root key name
@@ -259,6 +260,7 @@ class CommandTests(TempDirTestCase):
         original_kwargs = dict(
             app_name='my-app',
             app_version_attr='my_app.__version__',
+            binary_diff='my_module.MyBinaryDiff',
             repo_dir='repo/dir',
             keys_dir='keys/dir',
             key_map={name: [name] for name in role_names},


### PR DESCRIPTION
As explained in #154, `bsdiff4` may not always be the best option for patch creation.

As a workaround for users experiencing issues with `bsdiff4`, we now allow the use of alternative binary differencing solutions.

Users can subclass the abstract `BinaryDiff` (or the `DefaultBinaryDiff` implementation), and pass their subclass into the `Repository` and/or `Client` initializers using the *optional* `binary_diff` argument.

```python
class CustomBinaryDiff(BinaryDiff):
    @staticmethod
    def diff(*, src_bytes: bytes, dst_bytes: bytes) -> bytes:
        my_diff = ...
        return my_diff

    @staticmethod
    def patch(*, src_bytes: bytes, patch_bytes: bytes) -> bytes:
        my_patched = ...
        return my_patched
```

and then 

```python
repo = Repository(..., binary_diff=CustomBinaryDiff)
```
and/or

```python
client = Client(..., binary_diff=CustomBinaryDiff)
```

The custom binary diff class can also be specified in the `.tufup-repo-config` file. This can be done either manually, or via the `tufup init` CLI command. The "fully qualified name" of the custom class must be used, e.g. `my_module.CustomBinaryDiff`.

Note that the default implementation still uses `bsdiff4`:

```python
class DefaultBinaryDiff(BinaryDiff):
    diff = bsdiff4.diff
    patch = bsdiff4.patch
```